### PR TITLE
fix #256 & full review pass + optimization on normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Adds opt-in intra-operation Rayon scheduling to every accelerated CPU arithmetic
 ### CPU backends
 
 - Document normalization input headroom and fix single-round precision truncation, extreme offsets, and overflowing wide add/sub normalization.
-- Reduce normalization zeroing, specialize exact bit arithmetic by source width, and block serial i64 cross-base calls without changing scratch reservations.
-- Add bounded exact integer normalization tests, exhaustive centered small cases, and cross-base benchmark sweeps.
+- Reduce normalization zeroing, specialize exact bit arithmetic by source width, block serial i64 cross-base calls, and retain vector kernels for same-base truncation of at most one limb without changing scratch reservations.
+- Add bounded exact integer normalization tests, exhaustive centered small cases, and cross-base Criterion sweeps via `cargo bench --bench normalize` in `poulpy-cpu-avx`.
 - Restore selected-row VMP extraction forwarding for the NEON Rayon backend.
 - Fix cross-`base2k` normalization leaving output limbs outside `[-2^(base2k-1), 2^(base2k-1))` in `VecZnx` and FFT64/NTT4x30 `VecZnxBig`, including coefficient normalization and partial limbs ([#256](https://github.com/poulpy-fhe/poulpy/issues/256)).
 - Fix the FFT64 `vmp_apply_dft_to_dft` limb window when `res` is narrower than the prepared matrix: output limb `c` reads matrix limb `c + limb_offset`, but the window was clamped at `res.size()` instead of `res.size() + limb_offset`, dropping the top `limb_offset` limbs of every narrowed accumulating gadget digit. Shared by every FFT64 backend (reference, AVX2, AVX-512, NEON and their Rayon variants).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### `poulpy-hal`
 
+- **Breaking:** add overwrite and fused normalization methods to `ZnxExtractDigitAddMul`, with a `ZnxExtractDigitAddMulI128` counterpart for wide CPU backends.
 - **Breaking:** uniform `VecZnx` sampling now takes the target precision `k`; the sampler masks the unused low bits of the last live limb and clears limbs above `k`.
 - The cross-backend `test_vmp_apply_dft_to_dft_accumulate` now sweeps `res` sizes that differ from the prepared matrix size and non-zero `limb_offset`, so the output limb window is compared across transform families.
 
@@ -24,6 +25,11 @@ Adds opt-in intra-operation Rayon scheduling to every accelerated CPU arithmetic
 
 ### CPU backends
 
+- Document normalization input headroom and fix single-round precision truncation, extreme offsets, and overflowing wide add/sub normalization.
+- Reduce normalization zeroing, specialize exact bit arithmetic by source width, and block serial i64 cross-base calls without changing scratch reservations.
+- Add bounded exact integer normalization tests, exhaustive centered small cases, and cross-base benchmark sweeps.
+- Restore selected-row VMP extraction forwarding for the NEON Rayon backend.
+- Fix cross-`base2k` normalization leaving output limbs outside `[-2^(base2k-1), 2^(base2k-1))` in `VecZnx` and FFT64/NTT4x30 `VecZnxBig`, including coefficient normalization and partial limbs ([#256](https://github.com/poulpy-fhe/poulpy/issues/256)).
 - Fix the FFT64 `vmp_apply_dft_to_dft` limb window when `res` is narrower than the prepared matrix: output limb `c` reads matrix limb `c + limb_offset`, but the window was clamped at `res.size()` instead of `res.size() + limb_offset`, dropping the top `limb_offset` limbs of every narrowed accumulating gadget digit. Shared by every FFT64 backend (reference, AVX2, AVX-512, NEON and their Rayon variants).
 - Fix the NTT4x30 reference `vmp_apply_dft_to_dft_accumulate_tmp_bytes` under-reporting scratch when `res` is wider than the prepared matrix.
 - Add `poulpy-cpu-rayon`, which provides the shared Rayon executor, nested-parallelism guard, scheduling thresholds, FFT64 kernels, coefficient normalization, and tuning utilities used by the accelerated CPU crates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### `poulpy-hal`
 
 - Reject short source and carry slices before extraction kernels write, including the AVX2, AVX-512, IFMA and NEON implementations.
-- **Breaking:** add overwrite and fused normalization methods to `ZnxExtractDigitAddMul`, with a `ZnxExtractDigitAddMulI128` counterpart for wide CPU backends.
 - **Breaking:** uniform `VecZnx` sampling now takes the target precision `k`; the sampler masks the unused low bits of the last live limb and clears limbs above `k`.
 - The cross-backend `test_vmp_apply_dft_to_dft_accumulate` now sweeps `res` sizes that differ from the prepared matrix size and non-zero `limb_offset`, so the output limb window is compared across transform families.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Adds opt-in intra-operation Rayon scheduling to every accelerated CPU arithmetic
 
 - Document normalization input headroom and fix single-round precision truncation, extreme offsets, and overflowing wide add/sub normalization.
 - Reduce normalization zeroing, specialize exact bit arithmetic by source width, block serial i64 cross-base calls, and retain vector kernels for same-base truncation of at most one limb without changing scratch reservations.
-- Add bounded exact integer normalization tests, exhaustive centered small cases, and cross-base Criterion sweeps via `cargo bench --bench normalize` in `poulpy-cpu-avx`.
+- Add bounded exact integer normalization tests, centered boundary cases across usual and extreme base widths (full enumeration of bases 1 through 6 via `--ignored`), and cross-base Criterion sweeps via `cargo bench --bench normalize` in `poulpy-cpu-avx`.
 - Restore selected-row VMP extraction forwarding for the NEON Rayon backend.
 - Fix cross-`base2k` normalization leaving output limbs outside `[-2^(base2k-1), 2^(base2k-1))` in `VecZnx` and FFT64/NTT4x30 `VecZnxBig`, including coefficient normalization and partial limbs ([#256](https://github.com/poulpy-fhe/poulpy/issues/256)).
 - Fix the FFT64 `vmp_apply_dft_to_dft` limb window when `res` is narrower than the prepared matrix: output limb `c` reads matrix limb `c + limb_offset`, but the window was clamped at `res.size()` instead of `res.size() + limb_offset`, dropping the top `limb_offset` limbs of every narrowed accumulating gadget digit. Shared by every FFT64 backend (reference, AVX2, AVX-512, NEON and their Rayon variants).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### `poulpy-hal`
 
+- Reject short source and carry slices before extraction kernels write, including the AVX2, AVX-512, IFMA and NEON implementations.
 - **Breaking:** add overwrite and fused normalization methods to `ZnxExtractDigitAddMul`, with a `ZnxExtractDigitAddMulI128` counterpart for wide CPU backends.
 - **Breaking:** uniform `VecZnx` sampling now takes the target precision `k`; the sampler masks the unused low bits of the last live limb and clears limbs above `k`.
 - The cross-backend `test_vmp_apply_dft_to_dft_accumulate` now sweeps `res` sizes that differ from the prepared matrix size and non-zero `limb_offset`, so the output limb window is compared across transform families.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "cfg-if",
  "dashu-base",
  "num-modular",
+ "num-order",
  "static_assertions",
 ]
 
@@ -715,6 +716,7 @@ dependencies = [
  "byteorder",
  "criterion",
  "dashu-float",
+ "dashu-int",
  "itertools 0.15.0",
  "once_cell",
  "poulpy-bench",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ poulpy-bin-fhe = {path = "poulpy-bin-fhe"}
 poulpy-bench = {path = "poulpy-bench"}
 poulpy-ckks = {path = "poulpy-ckks", version = "0.8.2"}
 dashu-float = "0.6.0"
+dashu-int = "0.6.0"
 astro-float-num = { version = "0.3.7", default-features = false, features = ["std"] }
 # `poulpy-ckks` enables `unstable-float` only for its portable target graph.
 # Cargo then unifies that feature onto transitive users of this same libm; the

--- a/poulpy-bench/README.md
+++ b/poulpy-bench/README.md
@@ -163,3 +163,23 @@ cargo bench -p poulpy-cpu-ref --bench standard  --features enable-ckks -- "vec_z
 # See what a filter would run, without running it
 cargo bench -p poulpy-cpu-ref --bench standard --features enable-ckks -- --list "core"
 ```
+
+## Normalization sweep
+
+`hal::params::default_bench_params_normalize()` covers input and output bases
+`{17, 19, 21, 50, 51}`, offsets `{-a_base2k, 0, 1, a_base2k}`, equal input/output
+sizes `{4, 8, 16}`, and ring degrees `{4096, 65536}`, with one column. The Criterion
+runners `runner_vec_znx_normalize_sweep` and
+`runner_vec_znx_big_normalize_sweep` accept these parameters.
+
+The `normalize` benchmark compares small and big normalization on FFT64 and
+NTT4x30, with reference and AVX2 backends, for 4,800 cases. Input generation
+and allocation happen outside the timed loop, using the documented input bounds.
+
+```bash
+RUSTFLAGS="-C target-feature=+avx2,+fma" cargo bench \
+  -p poulpy-cpu-avx --features enable-avx --bench normalize
+```
+
+Append `-- 'k=17->19/offset=0'` to select a cross-base conversion, or
+`-- --list` to list cases. Results use Criterion's standard reports and baselines.

--- a/poulpy-bench/src/hal/helpers.rs
+++ b/poulpy-bench/src/hal/helpers.rs
@@ -46,6 +46,41 @@ pub fn random_host_vec_znx(n: usize, cols: usize, size: usize, source: &mut Sour
     VecZnx::from_bytes(n, cols, size, bytes)
 }
 
+fn random_normalization_bytes(len: usize, word_bytes: usize, source: &mut Source) -> Vec<u8> {
+    let mut bytes = random_aligned_host_bytes(len, source);
+    for word in bytes.chunks_exact_mut(word_bytes) {
+        match word_bytes {
+            8 => {
+                let value = i64::from_ne_bytes(word.try_into().unwrap()) >> 1;
+                word.copy_from_slice(&value.to_ne_bytes());
+            }
+            16 => {
+                let value = i128::from_ne_bytes(word.try_into().unwrap()) >> 1;
+                word.copy_from_slice(&value.to_ne_bytes());
+            }
+            _ => unreachable!("normalization requires i64 or i128 words"),
+        }
+    }
+    bytes
+}
+
+/// Random coefficients with the signed headroom required by normalization.
+pub fn random_normalization_vec_znx(n: usize, cols: usize, size: usize, source: &mut Source) -> VecZnx<Vec<u8>, i64> {
+    let bytes = random_normalization_bytes(VecZnx::<Vec<u8>, i64>::bytes_of(n, cols, size), size_of::<i64>(), source);
+    VecZnx::from_bytes(n, cols, size, bytes)
+}
+
+/// Random big coefficients bounded by 2^(word_bits-2).
+pub fn random_normalization_vec_znx_big<BE: Backend<ZnxWord = i64>>(
+    n: usize,
+    cols: usize,
+    size: usize,
+    source: &mut Source,
+) -> VecZnxBigOwned<BE> {
+    let bytes = random_normalization_bytes(BE::bytes_of_vec_znx_big(n, cols, size), size_of::<BE::BigWord>(), source);
+    VecZnxBigOwned::<BE>::from_bytes(n, cols, size, bytes)
+}
+
 pub fn random_host_mat_znx(
     n: usize,
     rows: usize,

--- a/poulpy-bench/src/hal/params.rs
+++ b/poulpy-bench/src/hal/params.rs
@@ -148,3 +148,43 @@ pub fn default_bench_params_cnv() -> Vec<CnvSweepParms> {
         CnvSweepParms { n: 1 << 15, size: 64 },
     ]
 }
+
+/// Base conversion and displacement parameters for normalization benchmarks.
+#[derive(Debug, Clone)]
+pub struct NormalizeSweepParams {
+    pub shape: HalSweepParms,
+    pub a_base2k: usize,
+    pub res_base2k: usize,
+    pub res_offset: i64,
+}
+
+impl Display for NormalizeSweepParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/k={}->{}/offset={}",
+            self.shape, self.a_base2k, self.res_base2k, self.res_offset
+        )
+    }
+}
+
+pub fn default_bench_params_normalize() -> Vec<NormalizeSweepParams> {
+    let mut result = Vec::new();
+    for n in [1 << 12, 1 << 16] {
+        for size in [4, 8, 16] {
+            for a_base2k in [17, 19, 21, 50, 51] {
+                for res_base2k in [17, 19, 21, 50, 51] {
+                    for res_offset in [-(a_base2k as i64), 0, 1, a_base2k as i64] {
+                        result.push(NormalizeSweepParams {
+                            shape: HalSweepParms { n, cols: 1, size },
+                            a_base2k,
+                            res_base2k,
+                            res_offset,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    result
+}

--- a/poulpy-bench/src/hal/suites.rs
+++ b/poulpy-bench/src/hal/suites.rs
@@ -30,11 +30,38 @@ use crate::{
         convolution,
         params::{
             CnvSweepParms, HalSweepParms, ReimSweepParams, VmpSweepParms, default_bench_params_cnv, default_bench_params_hal,
-            default_bench_params_vmp,
+            default_bench_params_normalize, default_bench_params_vmp,
         },
         reim, svp, vec_znx, vec_znx_big, vec_znx_dft, vmp,
     },
 };
+
+/// Small and big normalization across radix widths, offsets, sizes and degrees.
+pub fn bench_normalization<B: Backend<ZnxWord = i64>>(c: &mut Criterion<WallTime>)
+where
+    Module<B>: ModuleNew<B>
+        + VecZnxNormalize<B>
+        + VecZnxNormalizeTmpBytes
+        + VecZnxBigAlloc<B>
+        + VecZnxBigNormalize<B>
+        + VecZnxBigNormalizeTmpBytes,
+    ScratchOwned<B>: ScratchOwnedAlloc<B> + ScratchOwnedBorrow<B>,
+    B::OwnedBuf: AsRef<[u8]> + AsMut<[u8]>,
+{
+    let ops = [
+        BenchOp {
+            layer: "hal",
+            name: "vec_znx_normalize",
+            runner: vec_znx::runner_vec_znx_normalize_sweep::<B, WallTime>,
+        },
+        BenchOp {
+            layer: "hal",
+            name: "vec_znx_big_normalize",
+            runner: vec_znx_big::runner_vec_znx_big_normalize_sweep::<B, WallTime>,
+        },
+    ];
+    bench_ops(PhantomData::<B>, &ops, default_bench_params_normalize(), c);
+}
 
 // Op tables for each HAL capability group. Each function returns the raw
 // [`BenchOp`] table for that group only, scoped to the traits its own ops need —

--- a/poulpy-bench/src/hal/vec_znx/mod.rs
+++ b/poulpy-bench/src/hal/vec_znx/mod.rs
@@ -16,7 +16,7 @@ pub use add::{runner_vec_znx_add_assign, runner_vec_znx_add_into};
 pub use automorphism::{runner_vec_znx_automorphism, runner_vec_znx_automorphism_assign};
 pub use mul_xp_minus_one::{runner_vec_znx_mul_xp_minus_one, runner_vec_znx_mul_xp_minus_one_assign};
 pub use negate::{runner_vec_znx_negate, runner_vec_znx_negate_assign};
-pub use normalize::{runner_vec_znx_normalize, runner_vec_znx_normalize_assign};
+pub use normalize::{runner_vec_znx_normalize, runner_vec_znx_normalize_assign, runner_vec_znx_normalize_sweep};
 pub use rotate::{runner_vec_znx_rotate, runner_vec_znx_rotate_assign};
 pub use shift::{runner_vec_znx_lsh, runner_vec_znx_lsh_assign, runner_vec_znx_rsh, runner_vec_znx_rsh_assign};
 pub use sub::{runner_vec_znx_sub, runner_vec_znx_sub_assign, runner_vec_znx_sub_negate_assign};

--- a/poulpy-bench/src/hal/vec_znx/normalize.rs
+++ b/poulpy-bench/src/hal/vec_znx/normalize.rs
@@ -10,33 +10,60 @@ use poulpy_hal::{
     source::Source,
 };
 
-use crate::hal::helpers::{random_host_vec_znx, upload_host_vec_znx, vec_znx_backend_mut, vec_znx_backend_ref};
-use crate::hal::params::HalSweepParms;
+use crate::hal::helpers::{
+    random_host_vec_znx, random_normalization_vec_znx, upload_host_vec_znx, vec_znx_backend_mut, vec_znx_backend_ref,
+};
+use crate::hal::params::{HalSweepParms, NormalizeSweepParams};
 
 pub fn runner_vec_znx_normalize<B: Backend<ZnxWord = i64>, M: Measurement>(bencher: &mut Bencher<'_, M>, sweep: &HalSweepParms)
 where
     Module<B>: VecZnxNormalize<B> + ModuleNew<B> + VecZnxNormalizeTmpBytes,
     ScratchOwned<B>: ScratchOwnedAlloc<B> + ScratchOwnedBorrow<B>,
 {
-    let module: Module<B> = Module::<B>::new(sweep.n as u64);
+    runner_vec_znx_normalize_sweep::<B, M>(
+        bencher,
+        &NormalizeSweepParams {
+            shape: sweep.clone(),
+            a_base2k: 50,
+            res_base2k: 50,
+            res_offset: 0,
+        },
+    );
+}
 
-    let base2k: usize = 50;
+pub fn runner_vec_znx_normalize_sweep<B: Backend<ZnxWord = i64>, M: Measurement>(
+    bencher: &mut Bencher<'_, M>,
+    params: &NormalizeSweepParams,
+) where
+    Module<B>: VecZnxNormalize<B> + ModuleNew<B> + VecZnxNormalizeTmpBytes,
+    ScratchOwned<B>: ScratchOwnedAlloc<B> + ScratchOwnedBorrow<B>,
+{
+    let sweep = &params.shape;
+    let module: Module<B> = Module::<B>::new(sweep.n as u64);
 
     let mut source: Source = Source::new([0u8; 32]);
 
-    let a = random_host_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
+    let a = random_normalization_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
     let a = upload_host_vec_znx::<B>(&a);
     let res = random_host_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
     let mut res = upload_host_vec_znx::<B>(&res);
 
     let mut scratch: ScratchOwned<B> = ScratchOwned::alloc(module.vec_znx_normalize_tmp_bytes());
-    let res_offset: i64 = 0;
 
     bencher.iter(|| {
         let a = vec_znx_backend_ref::<B>(&a);
         let mut res = vec_znx_backend_mut::<B>(&mut res);
         for i in 0..sweep.cols {
-            module.vec_znx_normalize(&mut res, base2k, res_offset, i, &a, base2k, i, &mut scratch.borrow());
+            module.vec_znx_normalize(
+                &mut res,
+                params.res_base2k,
+                params.res_offset,
+                i,
+                &a,
+                params.a_base2k,
+                i,
+                &mut scratch.borrow(),
+            );
         }
         black_box(());
     });
@@ -55,7 +82,7 @@ pub fn runner_vec_znx_normalize_assign<B: Backend<ZnxWord = i64>, M: Measurement
 
     let mut source: Source = Source::new([0u8; 32]);
 
-    let a = random_host_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
+    let a = random_normalization_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
     let mut a = upload_host_vec_znx::<B>(&a);
 
     let mut scratch: ScratchOwned<B> = ScratchOwned::alloc(module.vec_znx_normalize_tmp_bytes());

--- a/poulpy-bench/src/hal/vec_znx_big.rs
+++ b/poulpy-bench/src/hal/vec_znx_big.rs
@@ -15,9 +15,10 @@ use poulpy_hal::{
 };
 
 use crate::hal::helpers::{
-    random_backend_vec_znx_big, random_host_vec_znx, upload_host_vec_znx, vec_znx_backend_mut, vec_znx_backend_ref,
+    random_backend_vec_znx_big, random_host_vec_znx, random_normalization_vec_znx_big, upload_host_vec_znx, vec_znx_backend_mut,
+    vec_znx_backend_ref,
 };
-use crate::hal::params::HalSweepParms;
+use crate::hal::params::{HalSweepParms, NormalizeSweepParams};
 
 pub fn runner_vec_znx_big_add_into<B: Backend<ZnxWord = i64>, M: Measurement>(bencher: &mut Bencher<'_, M>, sweep: &HalSweepParms)
 where
@@ -220,13 +221,31 @@ pub fn runner_vec_znx_big_normalize<B: Backend<ZnxWord = i64>, M: Measurement>(
     ScratchOwned<B>: ScratchOwnedAlloc<B> + ScratchOwnedBorrow<B>,
     B::OwnedBuf: AsRef<[u8]> + AsMut<[u8]>,
 {
-    let module: Module<B> = Module::<B>::new(sweep.n as u64);
+    runner_vec_znx_big_normalize_sweep::<B, M>(
+        bencher,
+        &NormalizeSweepParams {
+            shape: sweep.clone(),
+            a_base2k: 50,
+            res_base2k: 50,
+            res_offset: 0,
+        },
+    );
+}
 
-    let base2k: usize = 50;
+pub fn runner_vec_znx_big_normalize_sweep<B: Backend<ZnxWord = i64>, M: Measurement>(
+    bencher: &mut Bencher<'_, M>,
+    params: &NormalizeSweepParams,
+) where
+    Module<B>: VecZnxBigNormalize<B> + ModuleNew<B> + VecZnxBigNormalizeTmpBytes + VecZnxBigAlloc<B>,
+    ScratchOwned<B>: ScratchOwnedAlloc<B> + ScratchOwnedBorrow<B>,
+    B::OwnedBuf: AsRef<[u8]> + AsMut<[u8]>,
+{
+    let sweep = &params.shape;
+    let module: Module<B> = Module::<B>::new(sweep.n as u64);
 
     let mut source: Source = Source::new([0u8; 32]);
 
-    let a: VecZnxBigOwned<B> = random_backend_vec_znx_big::<B>(module.n(), sweep.cols, sweep.size, &mut source);
+    let a: VecZnxBigOwned<B> = random_normalization_vec_znx_big::<B>(module.n(), sweep.cols, sweep.size, &mut source);
     let res = random_host_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
     let mut res = upload_host_vec_znx::<B>(&res);
 
@@ -236,7 +255,16 @@ pub fn runner_vec_znx_big_normalize<B: Backend<ZnxWord = i64>, M: Measurement>(
         let a = a.to_backend_ref();
         let mut res = vec_znx_backend_mut::<B>(&mut res);
         for i in 0..sweep.cols {
-            module.vec_znx_big_normalize(&mut res, base2k, 0, i, &a, base2k, i, &mut scratch.borrow());
+            module.vec_znx_big_normalize(
+                &mut res,
+                params.res_base2k,
+                params.res_offset,
+                i,
+                &a,
+                params.a_base2k,
+                i,
+                &mut scratch.borrow(),
+            );
         }
         black_box(());
     });
@@ -259,7 +287,7 @@ pub fn runner_vec_znx_big_normalize_add_assign<B: Backend<ZnxWord = i64>, M: Mea
     let base2k: usize = 50;
     let mut source: Source = Source::new([0u8; 32]);
 
-    let a: VecZnxBigOwned<B> = random_backend_vec_znx_big::<B>(module.n(), sweep.cols, sweep.size, &mut source);
+    let a: VecZnxBigOwned<B> = random_normalization_vec_znx_big::<B>(module.n(), sweep.cols, sweep.size, &mut source);
     let res = random_host_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
     let mut res = upload_host_vec_znx::<B>(&res);
     let tmp = random_host_vec_znx(module.n(), 1, sweep.size, &mut source);
@@ -300,7 +328,7 @@ pub fn runner_vec_znx_big_normalize_sub_assign<B: Backend<ZnxWord = i64>, M: Mea
     let base2k: usize = 50;
     let mut source: Source = Source::new([0u8; 32]);
 
-    let a: VecZnxBigOwned<B> = random_backend_vec_znx_big::<B>(module.n(), sweep.cols, sweep.size, &mut source);
+    let a: VecZnxBigOwned<B> = random_normalization_vec_znx_big::<B>(module.n(), sweep.cols, sweep.size, &mut source);
     let res = random_host_vec_znx(module.n(), sweep.cols, sweep.size, &mut source);
     let mut res = upload_host_vec_znx::<B>(&res);
     let tmp = random_host_vec_znx(module.n(), 1, sweep.size, &mut source);

--- a/poulpy-cpu-arm/src/fft64/znx.rs
+++ b/poulpy-cpu-arm/src/fft64/znx.rs
@@ -236,8 +236,35 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Neon {
 
 impl ZnxExtractDigitAddMul for FFT64Neon {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        #[cfg(target_arch = "aarch64")]
+        crate::neon::znx_normalize::znx_extract_digit_mul_neon(base2k, lsh, res, src);
+        #[cfg(not(target_arch = "aarch64"))]
+        poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         kn_extract_digit_addmul(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        #[cfg(target_arch = "aarch64")]
+        crate::neon::znx_normalize::znx_extract_digit_addmul_normalize_neon::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
+        #[cfg(not(target_arch = "aarch64"))]
+        poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
     }
 }
 

--- a/poulpy-cpu-arm/src/fft64/znx.rs
+++ b/poulpy-cpu-arm/src/fft64/znx.rs
@@ -236,16 +236,18 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Neon {
 
 impl ZnxExtractDigitAddMul for FFT64Neon {
     #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        kn_extract_digit_addmul(base2k, lsh, res, src);
+    }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for FFT64Neon {
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         #[cfg(target_arch = "aarch64")]
         crate::neon::znx_normalize::znx_extract_digit_mul_neon(base2k, lsh, res, src);
         #[cfg(not(target_arch = "aarch64"))]
         poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
-    }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        kn_extract_digit_addmul(base2k, lsh, res, src);
     }
 
     #[inline(always)]

--- a/poulpy-cpu-arm/src/neon/normalize.rs
+++ b/poulpy-cpu-arm/src/neon/normalize.rs
@@ -364,11 +364,11 @@ pub(crate) unsafe fn nfc_extract_normalize_neon<const OVERWRITE: bool, const FIN
 ) {
     if base2k >= 64 || res_base2k >= 64 {
         if FINALIZE {
-            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k, lsh, res_base2k, res, src, carry,
             );
         } else {
-            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
         }
         return;
     }
@@ -395,7 +395,7 @@ pub(crate) unsafe fn nfc_extract_normalize_neon<const OVERWRITE: bool, const FIN
             }
         }
         if FINALIZE {
-            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k,
                 lsh,
                 res_base2k,
@@ -404,7 +404,7 @@ pub(crate) unsafe fn nfc_extract_normalize_neon<const OVERWRITE: bool, const FIN
                 &mut carry[end..],
             );
         } else {
-            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
         }
     }
 }
@@ -615,8 +615,8 @@ mod tests {
     }
     #[test]
     fn nfc_fused_matches_scalar() {
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Neon>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Neon>();
         #[cfg(feature = "enable-rayon")]
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30NeonRayon>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30NeonRayon>();
     }
 }

--- a/poulpy-cpu-arm/src/neon/normalize.rs
+++ b/poulpy-cpu-arm/src/neon/normalize.rs
@@ -186,7 +186,7 @@ unsafe fn nfc_final_chunk(s: &NfcShifts, lo_a: int64x2_t, lo_c: int64x2_t) -> in
 /// `base2k > 64`. Caller must satisfy `lsh < base2k`.
 #[inline]
 pub(crate) fn nfc_middle_step_neon(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
-    if base2k > 64 || res.len() < 2 {
+    if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step(base2k, lsh, res, a, carry);
         return;
     }
@@ -217,7 +217,7 @@ pub(crate) fn nfc_middle_step_neon(base2k: usize, lsh: usize, res: &mut [i64], a
 /// `nfc_middle_step_into` — fused middle step for `res ±= normalize(a)`.
 #[inline]
 pub(crate) fn nfc_middle_step_into_neon<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
-    if base2k > 64 || res.len() < 2 {
+    if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step_into::<O>(base2k, lsh, res, a, carry);
         return;
     }
@@ -261,7 +261,7 @@ pub(crate) fn nfc_middle_step_into_neon<O: AssignOp>(base2k: usize, lsh: usize, 
 /// `nfc_middle_step_assign` — in-place `i64` `res` update with `i128` carry.
 #[inline]
 pub(crate) fn nfc_middle_step_assign_neon(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
-    if base2k > 64 || res.len() < 2 {
+    if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step_assign(base2k, lsh, res, carry);
         return;
     }
@@ -290,7 +290,7 @@ pub(crate) fn nfc_middle_step_assign_neon(base2k: usize, lsh: usize, res: &mut [
 /// `nfc_final_step_assign` — flush i128 carry into the last i64 limb.
 #[inline]
 pub(crate) fn nfc_final_step_assign_neon(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
-    if base2k > 64 || res.len() < 2 {
+    if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_final_step_assign(base2k, lsh, res, carry);
         return;
     }
@@ -321,7 +321,7 @@ pub(crate) fn nfc_final_step_assign_neon(base2k: usize, lsh: usize, res: &mut [i
 /// `nfc_final_step_into` — fused final step for `res ±= normalize(a)`.
 #[inline]
 pub(crate) fn nfc_final_step_into_neon<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
-    if base2k > 64 || res.len() < 2 {
+    if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_final_step_into::<O>(base2k, lsh, res, carry);
         return;
     }
@@ -354,6 +354,61 @@ pub(crate) fn nfc_final_step_into_neon<O: AssignOp>(base2k: usize, lsh: usize, r
     }
 }
 
+pub(crate) unsafe fn nfc_extract_normalize_neon<const OVERWRITE: bool, const FINALIZE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i128],
+    carry: &mut [i128],
+) {
+    if base2k >= 64 || res_base2k >= 64 {
+        if FINALIZE {
+            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+                base2k, lsh, res_base2k, res, src, carry,
+            );
+        } else {
+            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+        }
+        return;
+    }
+    unsafe {
+        let source_shifts = NfcShifts::new(base2k as u32, 0);
+        let result_shifts = NfcShifts::new(res_base2k as u32, 0);
+        let scale = vdupq_n_s64(lsh as i64);
+        let zero = vdupq_n_s64(0);
+        let end = res.len() / 2 * 2;
+        for i in (0..end).step_by(2) {
+            let (a_lo, a_hi) = load2_split_i128(src.as_ptr().add(i));
+            let (digit, next_lo, next_hi) = nfc_middle_chunk(&source_shifts, a_lo, a_hi, zero, zero);
+            store2_split_i128(src.as_mut_ptr().add(i), next_lo, next_hi);
+            let initial = if OVERWRITE { zero } else { vld1q_s64(res.as_ptr().add(i)) };
+            let accum = vaddq_s64(initial, vshlq_s64(digit, scale));
+            if FINALIZE {
+                let (c_lo, c_hi) = load2_split_i128(carry.as_ptr().add(i));
+                let (out, next_lo, next_hi) =
+                    nfc_middle_chunk(&result_shifts, accum, vshlq_s64(accum, vdupq_n_s64(-63)), c_lo, c_hi);
+                vst1q_s64(res.as_mut_ptr().add(i), out);
+                store2_split_i128(carry.as_mut_ptr().add(i), next_lo, next_hi);
+            } else {
+                vst1q_s64(res.as_mut_ptr().add(i), accum);
+            }
+        }
+        if FINALIZE {
+            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+                base2k,
+                lsh,
+                res_base2k,
+                &mut res[end..],
+                &mut src[end..],
+                &mut carry[end..],
+            );
+        } else {
+            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -362,25 +417,45 @@ mod tests {
 
     /// Lengths exercise the SIMD body and the scalar tail.
     const LENGTHS: &[usize] = &[0, 1, 2, 3, 4, 5, 7, 8, 16, 17, 64, 65];
-    /// Representative `(base2k, lsh)` pairs spanning lsh==0 and lsh!=0.
-    const SHIFTS: &[(usize, usize)] = &[(12, 0), (50, 0), (50, 7), (60, 0), (60, 30), (64, 0), (64, 17)];
+    fn shifts() -> impl Iterator<Item = (usize, usize)> {
+        (1..=64).flat_map(|base2k| (0..base2k).map(move |lsh| (base2k, lsh)))
+    }
 
     fn rng() -> ChaCha8Rng {
         ChaCha8Rng::seed_from_u64(0xb00b_b00b_b00b_b00b)
     }
 
-    fn random_i128(rng: &mut ChaCha8Rng, n: usize) -> Vec<i128> {
+    fn random_i128(rng: &mut ChaCha8Rng, n: usize, base2k: usize) -> Vec<i128> {
         (0..n)
-            .map(|_| {
+            .map(|i| {
+                let half = 1i128 << (base2k - 1);
+                let bound = 1i128 << 126;
+                let idft_bound = 657821220234910467805273421263929344i128;
+                let special = [
+                    -bound,
+                    bound,
+                    -idft_bound,
+                    idft_bound,
+                    -half - 1,
+                    -half,
+                    half - 1,
+                    half,
+                    -1,
+                    0,
+                    1,
+                ];
+                if i % 13 < special.len() {
+                    return special[i % 13];
+                }
                 let lo: u64 = rng.random();
                 let hi: u64 = rng.random();
-                (((hi as u128) << 64) | lo as u128) as i128
+                ((((hi as u128) << 64) | lo as u128) as i128) >> 1
             })
             .collect()
     }
 
     fn random_i64(rng: &mut ChaCha8Rng, n: usize) -> Vec<i64> {
-        (0..n).map(|_| rng.random::<i64>()).collect()
+        (0..n).map(|_| rng.random::<i64>() >> 1).collect()
     }
 
     /// `AddOp` / `SubOp` re-export for tests.
@@ -390,12 +465,12 @@ mod tests {
     fn nfc_middle_step_matches_scalar() {
         let mut rng = rng();
         for &n in LENGTHS {
-            for &(b, l) in SHIFTS {
+            for (b, l) in shifts() {
                 if l >= b {
                     continue;
                 }
-                let a = random_i128(&mut rng, n);
-                let c0 = random_i128(&mut rng, n);
+                let a = random_i128(&mut rng, n, b);
+                let c0 = random_i128(&mut rng, n, b);
                 let mut got_r = vec![0i64; n];
                 let mut got_c = c0.clone();
                 let mut want_r = vec![0i64; n];
@@ -412,12 +487,12 @@ mod tests {
     fn nfc_middle_step_assign_matches_scalar() {
         let mut rng = rng();
         for &n in LENGTHS {
-            for &(b, l) in SHIFTS {
+            for (b, l) in shifts() {
                 if l >= b {
                     continue;
                 }
                 let r0 = random_i64(&mut rng, n);
-                let c0 = random_i128(&mut rng, n);
+                let c0 = random_i128(&mut rng, n, b);
                 let mut got_r = r0.clone();
                 let mut got_c = c0.clone();
                 let mut want_r = r0;
@@ -434,13 +509,13 @@ mod tests {
     fn nfc_middle_step_into_add_matches_scalar() {
         let mut rng = rng();
         for &n in LENGTHS {
-            for &(b, l) in SHIFTS {
+            for (b, l) in shifts() {
                 if l >= b {
                     continue;
                 }
                 let r0 = random_i64(&mut rng, n);
-                let a = random_i128(&mut rng, n);
-                let c0 = random_i128(&mut rng, n);
+                let a = random_i128(&mut rng, n, b);
+                let c0 = random_i128(&mut rng, n, b);
                 let mut got_r = r0.clone();
                 let mut got_c = c0.clone();
                 let mut want_r = r0;
@@ -457,13 +532,13 @@ mod tests {
     fn nfc_middle_step_into_sub_matches_scalar() {
         let mut rng = rng();
         for &n in LENGTHS {
-            for &(b, l) in SHIFTS {
+            for (b, l) in shifts() {
                 if l >= b {
                     continue;
                 }
                 let r0 = random_i64(&mut rng, n);
-                let a = random_i128(&mut rng, n);
-                let c0 = random_i128(&mut rng, n);
+                let a = random_i128(&mut rng, n, b);
+                let c0 = random_i128(&mut rng, n, b);
                 let mut got_r = r0.clone();
                 let mut got_c = c0.clone();
                 let mut want_r = r0;
@@ -480,12 +555,12 @@ mod tests {
     fn nfc_final_step_assign_matches_scalar() {
         let mut rng = rng();
         for &n in LENGTHS {
-            for &(b, l) in SHIFTS {
+            for (b, l) in shifts() {
                 if l >= b {
                     continue;
                 }
                 let r0 = random_i64(&mut rng, n);
-                let c0 = random_i128(&mut rng, n);
+                let c0 = random_i128(&mut rng, n, b);
                 let mut got_r = r0.clone();
                 let mut got_c = c0.clone();
                 let mut want_r = r0;
@@ -501,12 +576,12 @@ mod tests {
     fn nfc_final_step_into_add_matches_scalar() {
         let mut rng = rng();
         for &n in LENGTHS {
-            for &(b, l) in SHIFTS {
+            for (b, l) in shifts() {
                 if l >= b {
                     continue;
                 }
                 let r0 = random_i64(&mut rng, n);
-                let c0 = random_i128(&mut rng, n);
+                let c0 = random_i128(&mut rng, n, b);
                 let mut got_r = r0.clone();
                 let mut got_c = c0.clone();
                 let mut want_r = r0;
@@ -522,12 +597,12 @@ mod tests {
     fn nfc_final_step_into_sub_matches_scalar() {
         let mut rng = rng();
         for &n in LENGTHS {
-            for &(b, l) in SHIFTS {
+            for (b, l) in shifts() {
                 if l >= b {
                     continue;
                 }
                 let r0 = random_i64(&mut rng, n);
-                let c0 = random_i128(&mut rng, n);
+                let c0 = random_i128(&mut rng, n, b);
                 let mut got_r = r0.clone();
                 let mut got_c = c0.clone();
                 let mut want_r = r0;
@@ -537,5 +612,11 @@ mod tests {
                 assert_eq!(got_r, want_r, "res mismatch n={n} base2k={b} lsh={l}");
             }
         }
+    }
+    #[test]
+    fn nfc_fused_matches_scalar() {
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Neon>();
+        #[cfg(feature = "enable-rayon")]
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30NeonRayon>();
     }
 }

--- a/poulpy-cpu-arm/src/neon/znx_normalize.rs
+++ b/poulpy-cpu-arm/src/neon/znx_normalize.rs
@@ -3,10 +3,10 @@
 use core::arch::aarch64::{int64x2_t, vaddq_s64, vandq_s64, vdupq_n_s64, veorq_s64, vld1q_s64, vshlq_s64, vst1q_s64, vsubq_s64};
 
 use poulpy_cpu_ref::reference::znx::{
-    znx_extract_digit_addmul_ref, znx_normalize_digit_ref, znx_normalize_final_step_assign_ref, znx_normalize_final_step_ref,
-    znx_normalize_final_step_sub_ref, znx_normalize_first_step_assign_ref, znx_normalize_first_step_carry_only_ref,
-    znx_normalize_first_step_ref, znx_normalize_middle_step_assign_ref, znx_normalize_middle_step_carry_only_ref,
-    znx_normalize_middle_step_ref, znx_normalize_middle_step_sub_ref,
+    znx_normalize_digit_ref, znx_normalize_final_step_assign_ref, znx_normalize_final_step_ref, znx_normalize_final_step_sub_ref,
+    znx_normalize_first_step_assign_ref, znx_normalize_first_step_carry_only_ref, znx_normalize_first_step_ref,
+    znx_normalize_middle_step_assign_ref, znx_normalize_middle_step_carry_only_ref, znx_normalize_middle_step_ref,
+    znx_normalize_middle_step_sub_ref,
 };
 
 /// `(mask_k, sign_k, cnt_neg)` with `cnt_neg = -base2k` for `vshlq_s64` arithmetic right shift.
@@ -27,7 +27,7 @@ unsafe fn get_digit_neon(x: int64x2_t, mask_k: int64x2_t, sign_k: int64x2_t) -> 
     }
 }
 
-/// `carry = (x - digit) >>_arith base2k`.
+/// `carry = (x - digit) >>_arith base2k`; the subtraction must be representable.
 #[inline(always)]
 unsafe fn get_carry_neon(x: int64x2_t, digit: int64x2_t, cnt_neg: int64x2_t) -> int64x2_t {
     unsafe { vshlq_s64(vsubq_s64(x, digit), cnt_neg) }
@@ -35,7 +35,12 @@ unsafe fn get_carry_neon(x: int64x2_t, digit: int64x2_t, cnt_neg: int64x2_t) -> 
 
 /// `res += digit(src) << lsh` ; `src = carry`.
 #[inline]
-pub(crate) fn znx_extract_digit_addmul_neon(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+pub(crate) fn znx_extract_digit_addmul_impl_neon<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res: &mut [i64],
+    src: &mut [i64],
+) {
     debug_assert_eq!(res.len(), src.len());
     let n = res.len();
     let span = n >> 2;
@@ -51,8 +56,16 @@ pub(crate) fn znx_extract_digit_addmul_neon(base2k: usize, lsh: usize, res: &mut
             let d1 = get_digit_neon(s1, mask, sign);
             let c0 = get_carry_neon(s0, d0, cnt_neg);
             let c1 = get_carry_neon(s1, d1, cnt_neg);
-            let r0 = vaddq_s64(vld1q_s64(rr), vshlq_s64(d0, lsh_v));
-            let r1 = vaddq_s64(vld1q_s64(rr.add(2)), vshlq_s64(d1, lsh_v));
+            let r0 = if OVERWRITE {
+                vshlq_s64(d0, lsh_v)
+            } else {
+                vaddq_s64(vld1q_s64(rr), vshlq_s64(d0, lsh_v))
+            };
+            let r1 = if OVERWRITE {
+                vshlq_s64(d1, lsh_v)
+            } else {
+                vaddq_s64(vld1q_s64(rr.add(2)), vshlq_s64(d1, lsh_v))
+            };
             vst1q_s64(rr, r0);
             vst1q_s64(rr.add(2), r1);
             vst1q_s64(ss, c0);
@@ -63,8 +76,23 @@ pub(crate) fn znx_extract_digit_addmul_neon(base2k: usize, lsh: usize, res: &mut
     }
     let tail = span << 2;
     if tail < n {
-        znx_extract_digit_addmul_ref(base2k, lsh, &mut res[tail..], &mut src[tail..]);
+        poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_impl_ref::<OVERWRITE>(
+            base2k,
+            lsh,
+            &mut res[tail..],
+            &mut src[tail..],
+        );
     }
+}
+
+#[inline]
+pub(crate) fn znx_extract_digit_addmul_neon(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    znx_extract_digit_addmul_impl_neon::<false>(base2k, lsh, res, src);
+}
+
+#[inline]
+pub(crate) fn znx_extract_digit_mul_neon(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    znx_extract_digit_addmul_impl_neon::<true>(base2k, lsh, res, src);
 }
 
 /// `res = digit(res)` ; `src += carry(res)`.
@@ -628,5 +656,63 @@ pub(crate) fn znx_normalize_final_step_sub_neon(base2k: usize, lsh: usize, x: &m
     let tail = span << 2;
     if tail < n {
         znx_normalize_final_step_sub_ref(base2k, lsh, &mut x[tail..], &a[tail..], &mut carry[tail..]);
+    }
+}
+
+/// Extracts the completing subdigit and normalizes the destination in one pass.
+#[inline]
+pub(crate) fn znx_extract_digit_addmul_normalize_neon<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i64],
+    carry: &mut [i64],
+) {
+    debug_assert_eq!(res.len(), src.len());
+    debug_assert!(carry.len() >= res.len());
+    let end = res.len() / 2 * 2;
+    unsafe {
+        let (mask, sign, shift) = normalize_consts_neon(base2k);
+        let (res_mask, res_sign, res_shift) = normalize_consts_neon(res_base2k);
+        let scale = vdupq_n_s64(lsh as i64);
+        for i in (0..end).step_by(2) {
+            let source = vld1q_s64(src.as_ptr().add(i));
+            let digit = get_digit_neon(source, mask, sign);
+            let quotient = get_carry_neon(source, digit, shift);
+            let partial = if OVERWRITE {
+                vshlq_s64(digit, scale)
+            } else {
+                vaddq_s64(vld1q_s64(res.as_ptr().add(i)), vshlq_s64(digit, scale))
+            };
+            let sum = vaddq_s64(partial, vld1q_s64(carry.as_ptr().add(i)));
+            let output = get_digit_neon(sum, res_mask, res_sign);
+            let output_carry = get_carry_neon(sum, output, res_shift);
+            vst1q_s64(src.as_mut_ptr().add(i), quotient);
+            vst1q_s64(res.as_mut_ptr().add(i), output);
+            vst1q_s64(carry.as_mut_ptr().add(i), output_carry);
+        }
+    }
+    poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(
+        base2k,
+        lsh,
+        res_base2k,
+        &mut res[end..],
+        &mut src[end..],
+        &mut carry[end..],
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_normalization_kernels_bounded_inputs() {
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Neon>();
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Neon>();
+        #[cfg(feature = "enable-rayon")]
+        {
+            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64NeonRayon>();
+            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30NeonRayon>();
+        }
     }
 }

--- a/poulpy-cpu-arm/src/neon/znx_normalize.rs
+++ b/poulpy-cpu-arm/src/neon/znx_normalize.rs
@@ -41,7 +41,7 @@ pub(crate) fn znx_extract_digit_addmul_impl_neon<const OVERWRITE: bool>(
     res: &mut [i64],
     src: &mut [i64],
 ) {
-    debug_assert_eq!(res.len(), src.len());
+    assert!(src.len() >= res.len());
     let n = res.len();
     let span = n >> 2;
     unsafe {
@@ -669,8 +669,8 @@ pub(crate) fn znx_extract_digit_addmul_normalize_neon<const OVERWRITE: bool>(
     src: &mut [i64],
     carry: &mut [i64],
 ) {
-    debug_assert_eq!(res.len(), src.len());
-    debug_assert!(carry.len() >= res.len());
+    assert!(src.len() >= res.len());
+    assert!(carry.len() >= res.len());
     let end = res.len() / 2 * 2;
     unsafe {
         let (mask, sign, shift) = normalize_consts_neon(base2k);

--- a/poulpy-cpu-arm/src/neon/znx_normalize.rs
+++ b/poulpy-cpu-arm/src/neon/znx_normalize.rs
@@ -707,12 +707,12 @@ pub(crate) fn znx_extract_digit_addmul_normalize_neon<const OVERWRITE: bool>(
 mod tests {
     #[test]
     fn test_normalization_kernels_bounded_inputs() {
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Neon>();
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Neon>();
+        poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::FFT64Neon>();
+        poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Neon>();
         #[cfg(feature = "enable-rayon")]
         {
-            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64NeonRayon>();
-            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30NeonRayon>();
+            poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::FFT64NeonRayon>();
+            poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30NeonRayon>();
         }
     }
 }

--- a/poulpy-cpu-arm/src/ntt4x30/rayon.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/rayon.rs
@@ -201,7 +201,29 @@ forward_znx!(ZnxNormalizeMiddleStepAssign, znx_normalize_middle_step_assign(base
 forward_znx!(ZnxNormalizeMiddleStepSub, znx_normalize_middle_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 forward_znx!(ZnxNormalizeFinalStepSub, znx_normalize_final_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 forward_znx!(ZnxNormalizeFinalStepAssign, znx_normalize_final_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64]));
-forward_znx!(ZnxExtractDigitAddMul, znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]));
+impl ZnxExtractDigitAddMul for NTT4x30NeonRayon {
+    #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT4x30Neon as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT4x30Neon as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <NTT4x30Neon as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
+    }
+}
 forward_znx!(ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
 
 impl NttDFTExecute<NttTable<Primes30>> for NTT4x30NeonRayon {
@@ -561,6 +583,22 @@ unsafe impl HalVmpImpl<NTT4x30NeonRayon> for NTT4x30NeonRayon {
                 tmp,
             );
         }
+    }
+
+    fn vmp_extract_selected_rows(
+        module: &Module<Self>,
+        res: &mut VmpPMatBackendMut<'_, Self>,
+        a: &VmpPMatBackendRef<'_, Self>,
+        first_row: usize,
+        row_step: usize,
+    ) {
+        <NTT4x30Neon as HalVmpImpl<NTT4x30Neon>>::vmp_extract_selected_rows(
+            base_module(module),
+            &mut base_vmp_mut(res),
+            &base_vmp_ref(a),
+            first_row,
+            row_step,
+        )
     }
 
     fn vmp_zero(module: &Module<Self>, res: &mut VmpPMatBackendMut<'_, Self>) {
@@ -937,6 +975,27 @@ impl poulpy_cpu_rayon::RayonTuning for NTT4x30NeonRayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
+}
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30NeonRayon {
+    const FUSE_NORMALIZE: bool = <NTT4x30Neon as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Neon as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Neon as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-arm/src/ntt4x30/rayon.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/rayon.rs
@@ -206,10 +206,14 @@ impl ZnxExtractDigitAddMul for NTT4x30NeonRayon {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT4x30Neon as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
     }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30NeonRayon {
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        <NTT4x30Neon as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+        <NTT4x30Neon as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }
+
     #[inline(always)]
     fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
         base2k: usize,
@@ -219,7 +223,7 @@ impl ZnxExtractDigitAddMul for NTT4x30NeonRayon {
         src: &mut [i64],
         carry: &mut [i64],
     ) {
-        <NTT4x30Neon as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+        <NTT4x30Neon as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
             base2k, lsh, res_base2k, res, src, carry,
         );
     }
@@ -370,6 +374,25 @@ impl I128BigOps for NTT4x30NeonRayon {
 }
 
 impl I128NormalizeOps for NTT4x30NeonRayon {
+    const FUSE_NORMALIZE: bool = <NTT4x30Neon as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Neon as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Neon as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        )
+    }
+
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         <NTT4x30Neon as I128NormalizeOps>::nfc_middle_step(base2k, lsh, res, a, carry)
     }
@@ -975,27 +998,6 @@ impl poulpy_cpu_rayon::RayonTuning for NTT4x30NeonRayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
-}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30NeonRayon {
-    const FUSE_NORMALIZE: bool = <NTT4x30Neon as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
-
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        <NTT4x30Neon as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        <NTT4x30Neon as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
-            base2k, lsh, res_base2k, res, src, carry,
-        )
-    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
@@ -118,3 +118,24 @@ impl I128NormalizeOps for NTT4x30Neon {
 
 #[cfg(not(target_arch = "aarch64"))]
 impl I128NormalizeOps for NTT4x30Neon {}
+
+#[cfg(target_arch = "aarch64")]
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Neon {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
+    }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Neon {}

--- a/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
@@ -122,6 +122,7 @@ impl I128NormalizeOps for NTT4x30Neon {}
 #[cfg(target_arch = "aarch64")]
 impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Neon {
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
         unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
     }
 
@@ -133,6 +134,8 @@ impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Neon {
         src: &mut [i128],
         carry: &mut [i128],
     ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
         unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
     }
 }

--- a/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
@@ -94,6 +94,24 @@ impl poulpy_cpu_ref::hal_defaults::BigWordHadamardProduct for NTT4x30Neon {
 
 #[cfg(target_arch = "aarch64")]
 impl I128NormalizeOps for NTT4x30Neon {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
+        unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
+    }
+
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         nfc_middle_step_neon(base2k, lsh, res, a, carry);
@@ -118,27 +136,3 @@ impl I128NormalizeOps for NTT4x30Neon {
 
 #[cfg(not(target_arch = "aarch64"))]
 impl I128NormalizeOps for NTT4x30Neon {}
-
-#[cfg(target_arch = "aarch64")]
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Neon {
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        assert!(src.len() >= res.len());
-        unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        assert!(src.len() >= res.len());
-        assert!(carry.len() >= res.len());
-        unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
-    }
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Neon {}

--- a/poulpy-cpu-arm/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/znx.rs
@@ -236,16 +236,18 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Neon {
 
 impl ZnxExtractDigitAddMul for NTT4x30Neon {
     #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        kn_extract_digit_addmul(base2k, lsh, res, src);
+    }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Neon {
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         #[cfg(target_arch = "aarch64")]
         crate::neon::znx_normalize::znx_extract_digit_mul_neon(base2k, lsh, res, src);
         #[cfg(not(target_arch = "aarch64"))]
         poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
-    }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        kn_extract_digit_addmul(base2k, lsh, res, src);
     }
 
     #[inline(always)]

--- a/poulpy-cpu-arm/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/znx.rs
@@ -236,8 +236,35 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Neon {
 
 impl ZnxExtractDigitAddMul for NTT4x30Neon {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        #[cfg(target_arch = "aarch64")]
+        crate::neon::znx_normalize::znx_extract_digit_mul_neon(base2k, lsh, res, src);
+        #[cfg(not(target_arch = "aarch64"))]
+        poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         kn_extract_digit_addmul(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        #[cfg(target_arch = "aarch64")]
+        crate::neon::znx_normalize::znx_extract_digit_addmul_normalize_neon::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
+        #[cfg(not(target_arch = "aarch64"))]
+        poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
     }
 }
 

--- a/poulpy-cpu-avx/Cargo.toml
+++ b/poulpy-cpu-avx/Cargo.toml
@@ -61,3 +61,8 @@ required-features = ["enable-avx", "enable-ckks"]
 name = "light"
 harness = false
 required-features = ["enable-avx", "enable-ckks"]
+
+[[bench]]
+name = "normalize"
+harness = false
+required-features = ["enable-avx"]

--- a/poulpy-cpu-avx/benches/normalize.rs
+++ b/poulpy-cpu-avx/benches/normalize.rs
@@ -1,0 +1,18 @@
+//! Normalization sweeps for reference and AVX2 FFT64 and NTT4x30 backends.
+
+use criterion::{criterion_group, criterion_main};
+use poulpy_bench::hal::suites::bench_normalization;
+use poulpy_cpu_avx::{FFT64Avx, NTT4x30Avx};
+use poulpy_cpu_ref::{FFT64Ref, NTT4x30Ref};
+
+criterion_group! {
+    name = benches;
+    config = poulpy_bench::criterion_config();
+    targets =
+        bench_normalization::<FFT64Ref>,
+        bench_normalization::<NTT4x30Ref>,
+        bench_normalization::<FFT64Avx>,
+        bench_normalization::<NTT4x30Avx>
+}
+
+criterion_main!(benches);

--- a/poulpy-cpu-avx/src/fft64/module.rs
+++ b/poulpy-cpu-avx/src/fft64/module.rs
@@ -451,16 +451,18 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Avx {
 
 impl ZnxExtractDigitAddMul for FFT64Avx {
     #[inline(always)]
-    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        unsafe {
-            crate::znx_avx::znx_extract_digit_mul_avx(base2k, lsh, res, src);
-        }
-    }
-
-    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             znx_extract_digit_addmul_avx(base2k, lsh, res, src);
+        }
+    }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for FFT64Avx {
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe {
+            crate::znx_avx::znx_extract_digit_mul_avx(base2k, lsh, res, src);
         }
     }
 

--- a/poulpy-cpu-avx/src/fft64/module.rs
+++ b/poulpy-cpu-avx/src/fft64/module.rs
@@ -451,9 +451,30 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Avx {
 
 impl ZnxExtractDigitAddMul for FFT64Avx {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe {
+            crate::znx_avx::znx_extract_digit_mul_avx(base2k, lsh, res, src);
+        }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             znx_extract_digit_addmul_avx(base2k, lsh, res, src);
+        }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        unsafe {
+            crate::znx_avx::znx_extract_digit_addmul_normalize_avx::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
         }
     }
 }

--- a/poulpy-cpu-avx/src/ntt4x30/rayon.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/rayon.rs
@@ -225,10 +225,14 @@ impl ZnxExtractDigitAddMul for NTT4x30AvxRayon {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT4x30Avx as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
     }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30AvxRayon {
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        <NTT4x30Avx as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+        <NTT4x30Avx as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }
+
     #[inline(always)]
     fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
         base2k: usize,
@@ -238,7 +242,7 @@ impl ZnxExtractDigitAddMul for NTT4x30AvxRayon {
         src: &mut [i64],
         carry: &mut [i64],
     ) {
-        <NTT4x30Avx as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+        <NTT4x30Avx as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
             base2k, lsh, res_base2k, res, src, carry,
         );
     }
@@ -389,6 +393,25 @@ impl I128BigOps for NTT4x30AvxRayon {
 }
 
 impl I128NormalizeOps for NTT4x30AvxRayon {
+    const FUSE_NORMALIZE: bool = <NTT4x30Avx as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Avx as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Avx as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        )
+    }
+
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         <NTT4x30Avx as I128NormalizeOps>::nfc_middle_step(base2k, lsh, res, a, carry)
     }
@@ -1435,27 +1458,6 @@ impl poulpy_cpu_rayon::RayonTuning for NTT4x30AvxRayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
-}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30AvxRayon {
-    const FUSE_NORMALIZE: bool = <NTT4x30Avx as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
-
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        <NTT4x30Avx as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        <NTT4x30Avx as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
-            base2k, lsh, res_base2k, res, src, carry,
-        )
-    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-avx/src/ntt4x30/rayon.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/rayon.rs
@@ -220,7 +220,29 @@ forward_znx!(ZnxNormalizeMiddleStepAssign, znx_normalize_middle_step_assign(base
 forward_znx!(ZnxNormalizeMiddleStepSub, znx_normalize_middle_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 forward_znx!(ZnxNormalizeFinalStepSub, znx_normalize_final_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 forward_znx!(ZnxNormalizeFinalStepAssign, znx_normalize_final_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64]));
-forward_znx!(ZnxExtractDigitAddMul, znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]));
+impl ZnxExtractDigitAddMul for NTT4x30AvxRayon {
+    #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT4x30Avx as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT4x30Avx as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <NTT4x30Avx as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
+    }
+}
 forward_znx!(ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
 
 impl NttDFTExecute<NttTable<Primes30>> for NTT4x30AvxRayon {
@@ -1413,6 +1435,27 @@ impl poulpy_cpu_rayon::RayonTuning for NTT4x30AvxRayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
+}
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30AvxRayon {
+    const FUSE_NORMALIZE: bool = <NTT4x30Avx as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Avx as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Avx as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
@@ -1,6 +1,6 @@
 //! Large-coefficient (i128) ring element vector support for [`NTT4x30Avx`](super::NTT4x30Avx).
 //!
-//! The shared `poulpy-hal` NTT4x30 defaults rely on backend-provided `I128BigOps`
+//! The shared `poulpy-cpu-ref` NTT4x30 defaults rely on backend-provided `I128BigOps`
 //! and `I128NormalizeOps` hooks for vectorized i128 operations.
 
 use super::{
@@ -93,6 +93,24 @@ impl BigWordHadamardProduct for NTT4x30Avx {
 }
 
 impl I128NormalizeOps for NTT4x30Avx {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
+        unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
+    }
+
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         // SAFETY: NTT4x30Avx::new() verifies AVX2 availability at construction time.
@@ -121,25 +139,5 @@ impl I128NormalizeOps for NTT4x30Avx {
         } else {
             nfc_final_step_assign_scalar(base2k, lsh, res, carry);
         }
-    }
-}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx {
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        assert!(src.len() >= res.len());
-        unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        assert!(src.len() >= res.len());
-        assert!(carry.len() >= res.len());
-        unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
     }
 }

--- a/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
@@ -126,6 +126,7 @@ impl I128NormalizeOps for NTT4x30Avx {
 
 impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx {
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
         unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
     }
 
@@ -137,6 +138,8 @@ impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx {
         src: &mut [i128],
         carry: &mut [i128],
     ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
         unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
     }
 }

--- a/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
@@ -123,3 +123,20 @@ impl I128NormalizeOps for NTT4x30Avx {
         }
     }
 }
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry) }
+    }
+}

--- a/poulpy-cpu-avx/src/ntt4x30/vec_znx_big_avx.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/vec_znx_big_avx.rs
@@ -963,11 +963,11 @@ pub(super) unsafe fn nfc_extract_normalize_avx2<const OVERWRITE: bool, const FIN
 ) {
     if base2k >= 64 || res_base2k >= 64 {
         if FINALIZE {
-            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k, lsh, res_base2k, res, src, carry,
             );
         } else {
-            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
         }
         return;
     }
@@ -1010,7 +1010,7 @@ pub(super) unsafe fn nfc_extract_normalize_avx2<const OVERWRITE: bool, const FIN
             }
         }
         if FINALIZE {
-            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k,
                 lsh,
                 res_base2k,
@@ -1019,7 +1019,7 @@ pub(super) unsafe fn nfc_extract_normalize_avx2<const OVERWRITE: bool, const FIN
                 &mut carry[end..],
             );
         } else {
-            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
         }
     }
 }
@@ -1198,8 +1198,8 @@ mod tests {
     }
     #[test]
     fn nfc_fused_matches_scalar() {
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx>();
         #[cfg(feature = "enable-rayon")]
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30AvxRayon>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30AvxRayon>();
     }
 }

--- a/poulpy-cpu-avx/src/ntt4x30/vec_znx_big_avx.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/vec_znx_big_avx.rs
@@ -286,6 +286,11 @@ unsafe fn nfc_final_chunk(s: &NfcShifts, lo_a: __m256i, lo_c: __m256i) -> __m256
 /// Requires AVX2.  `res`, `a`, `carry` must each have at least `n` elements.
 #[target_feature(enable = "avx2")]
 pub(super) unsafe fn nfc_middle_step_avx2(base2k: u32, lsh: u32, n: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+    if base2k >= 64 {
+        nfc_middle_step_scalar(base2k as usize, lsh as usize, res, a, carry);
+        return;
+    }
+
     unsafe {
         let s = NfcShifts::new(base2k, lsh);
         let a_ptr = a.as_ptr() as *const __m256i;
@@ -333,6 +338,11 @@ pub(super) unsafe fn nfc_middle_step_avx2(base2k: u32, lsh: u32, n: usize, res: 
 /// Requires AVX2.
 #[target_feature(enable = "avx2")]
 pub(super) unsafe fn nfc_middle_step_assign_avx2(base2k: u32, lsh: u32, n: usize, res: &mut [i64], carry: &mut [i128]) {
+    if base2k >= 64 {
+        nfc_middle_step_assign_scalar(base2k as usize, lsh as usize, res, carry);
+        return;
+    }
+
     unsafe {
         let s = NfcShifts::new(base2k, lsh);
         let c_ptr = carry.as_mut_ptr() as *mut __m256i;
@@ -942,6 +952,78 @@ pub(super) unsafe fn vi128_neg_from_small_avx2(n: usize, res: &mut [i128], a: &[
 // Tests
 // ──────────────────────────────────────────────────────────────────────────────
 
+#[target_feature(enable = "avx2")]
+pub(super) unsafe fn nfc_extract_normalize_avx2<const OVERWRITE: bool, const FINALIZE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i128],
+    carry: &mut [i128],
+) {
+    if base2k >= 64 || res_base2k >= 64 {
+        if FINALIZE {
+            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+                base2k, lsh, res_base2k, res, src, carry,
+            );
+        } else {
+            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+        }
+        return;
+    }
+    unsafe {
+        let source_shifts = NfcShifts::new(base2k as u32, 0);
+        let result_shifts = NfcShifts::new(res_base2k as u32, 0);
+        let scale = _mm_cvtsi64_si128(lsh as i64);
+        let zero = _mm256_setzero_si256();
+
+        let load = |ptr: *const i128| {
+            let x0 = _mm256_loadu_si256(ptr.cast::<__m256i>());
+            let x1 = _mm256_loadu_si256(ptr.cast::<__m256i>().add(1));
+            (_mm256_unpacklo_epi64(x0, x1), _mm256_unpackhi_epi64(x0, x1))
+        };
+        let store = |ptr: *mut i128, lo, hi| {
+            _mm256_storeu_si256(ptr.cast::<__m256i>(), _mm256_unpacklo_epi64(lo, hi));
+            _mm256_storeu_si256(ptr.cast::<__m256i>().add(1), _mm256_unpackhi_epi64(lo, hi));
+        };
+        let end = res.len() / 4 * 4;
+        for i in (0..end).step_by(4) {
+            let (a_lo, a_hi) = load(src.as_ptr().add(i));
+            let (digit, next_lo, next_hi) = nfc_middle_chunk(&source_shifts, a_lo, a_hi, zero, zero);
+            store(src.as_mut_ptr().add(i), next_lo, next_hi);
+            let initial = if OVERWRITE {
+                zero
+            } else {
+                _mm256_permute4x64_epi64(_mm256_loadu_si256(res.as_ptr().add(i).cast::<__m256i>()), 0xD8)
+            };
+            let accum = _mm256_add_epi64(initial, _mm256_sll_epi64(digit, scale));
+            if FINALIZE {
+                let (c_lo, c_hi) = load(carry.as_ptr().add(i));
+                let (out, next_lo, next_hi) = nfc_middle_chunk(&result_shifts, accum, sra_epi64(accum, 63), c_lo, c_hi);
+                _mm256_storeu_si256(res.as_mut_ptr().add(i).cast::<__m256i>(), _mm256_permute4x64_epi64(out, 0xD8));
+                store(carry.as_mut_ptr().add(i), next_lo, next_hi);
+            } else {
+                _mm256_storeu_si256(
+                    res.as_mut_ptr().add(i).cast::<__m256i>(),
+                    _mm256_permute4x64_epi64(accum, 0xD8),
+                );
+            }
+        }
+        if FINALIZE {
+            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+                base2k,
+                lsh,
+                res_base2k,
+                &mut res[end..],
+                &mut src[end..],
+                &mut carry[end..],
+            );
+        } else {
+            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+        }
+    }
+}
+
 #[cfg(all(test, target_feature = "avx2"))]
 mod tests {
     use super::{
@@ -1050,62 +1132,74 @@ mod tests {
     }
 
     #[test]
-    fn nfc_middle_step_avx2_vs_scalar() {
-        let n = 64usize;
-        let base2k = 16usize;
-        let lsh = 0usize;
-        let a = i128_data(n, 37i128);
-        let carry_init: Vec<i128> = (0..n).map(|i| (i as i128 * 3) % (1i128 << 20)).collect();
-
-        let mut res_avx = vec![0i64; n];
-        let mut carry_avx = carry_init.clone();
-        let mut res_ref = vec![0i64; n];
-        let mut carry_ref = carry_init.clone();
-
-        unsafe { nfc_middle_step_avx2(base2k as u32, lsh as u32, n, &mut res_avx, &a, &mut carry_avx) };
-        nfc_middle_step_scalar(base2k, lsh, &mut res_ref, &a, &mut carry_ref);
-
-        assert_eq!(res_avx, res_ref, "nfc_middle_step res mismatch");
-        assert_eq!(carry_avx, carry_ref, "nfc_middle_step carry mismatch");
+    fn nfc_bounded_inputs_match_scalar() {
+        let bound = 1i128 << 126;
+        let idft_bound = 657821220234910467805273421263929344i128;
+        for base2k in 1..=63 {
+            let half = 1i128 << (base2k - 1);
+            let mut a = vec![
+                -bound,
+                bound,
+                0,
+                1,
+                -1,
+                half,
+                -half,
+                half - 1,
+                -half - 1,
+                i64::MIN as i128,
+                i64::MAX as i128,
+                idft_bound,
+                -idft_bound,
+            ];
+            let mut state = 0x123456789abcdef0u128;
+            for _ in 0..10 {
+                state ^= state << 17;
+                state ^= state >> 29;
+                state ^= state << 43;
+                a.push((state as i128) >> 1);
+            }
+            let n = a.len();
+            for lsh in 0..base2k {
+                for round in 0..3 {
+                    let carry: Vec<_> = (0..n).map(|i| a[(i + round) % n]).collect();
+                    let initial: Vec<_> = a.iter().map(|&v| (v as i64) >> 1).collect();
+                    let mut want = initial.clone();
+                    let mut got = initial.clone();
+                    let mut want_carry = carry.clone();
+                    let mut got_carry = carry.clone();
+                    nfc_middle_step_scalar(base2k, lsh, &mut want, &a, &mut want_carry);
+                    if lsh == 0 && round == 0 {
+                        assert_eq!((want[1], want_carry[1]), (0, bound >> (base2k - 1)));
+                    }
+                    unsafe { nfc_middle_step_avx2(base2k as u32, lsh as u32, n, &mut got, &a, &mut got_carry) };
+                    assert_eq!(
+                        (&got, &got_carry),
+                        (&want, &want_carry),
+                        "middle k={base2k} lsh={lsh} round={round}"
+                    );
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    nfc_middle_step_assign_scalar(base2k, lsh, &mut want, &mut want_carry);
+                    unsafe { nfc_middle_step_assign_avx2(base2k as u32, lsh as u32, n, &mut got, &mut got_carry) };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "assign k={base2k} lsh={lsh}");
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    nfc_final_step_assign_scalar(base2k, lsh, &mut want, &mut want_carry);
+                    unsafe { nfc_final_step_assign_avx2(base2k as u32, lsh as u32, n, &mut got, &mut got_carry) };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "final k={base2k} lsh={lsh}");
+                }
+            }
+        }
     }
-
     #[test]
-    fn nfc_middle_step_assign_avx2_vs_scalar() {
-        let n = 64usize;
-        let base2k = 16usize;
-        let lsh = 8usize;
-        let init: Vec<i64> = (0..n).map(|i| (i as i64 * 5) % (1i64 << 20)).collect();
-        let carry_init: Vec<i128> = (0..n).map(|i| (i as i128 * 7) % (1i128 << 20)).collect();
-
-        let mut res_avx = init.clone();
-        let mut carry_avx = carry_init.clone();
-        let mut res_ref = init.clone();
-        let mut carry_ref = carry_init.clone();
-
-        unsafe { nfc_middle_step_assign_avx2(base2k as u32, lsh as u32, n, &mut res_avx, &mut carry_avx) };
-        nfc_middle_step_assign_scalar(base2k, lsh, &mut res_ref, &mut carry_ref);
-
-        assert_eq!(res_avx, res_ref, "nfc_middle_step_assign res mismatch");
-        assert_eq!(carry_avx, carry_ref, "nfc_middle_step_assign carry mismatch");
-    }
-
-    #[test]
-    fn nfc_final_step_assign_avx2_vs_scalar() {
-        let n = 64usize;
-        let base2k = 16usize;
-        let lsh = 0usize;
-        let init: Vec<i64> = (0..n).map(|i| (i as i64 * 3) % (1i64 << 20)).collect();
-        let carry_init: Vec<i128> = (0..n).map(|i| (i as i128 * 11) % (1i128 << 20)).collect();
-
-        let mut res_avx = init.clone();
-        let mut carry_avx = carry_init.clone();
-        let mut res_ref = init.clone();
-        let mut carry_ref = carry_init.clone();
-
-        unsafe { nfc_final_step_assign_avx2(base2k as u32, lsh as u32, n, &mut res_avx, &mut carry_avx) };
-        nfc_final_step_assign_scalar(base2k, lsh, &mut res_ref, &mut carry_ref);
-
-        assert_eq!(res_avx, res_ref, "nfc_final_step_assign res mismatch");
-        assert_eq!(carry_avx, carry_ref, "nfc_final_step_assign carry mismatch");
+    fn nfc_fused_matches_scalar() {
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx>();
+        #[cfg(feature = "enable-rayon")]
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30AvxRayon>();
     }
 }

--- a/poulpy-cpu-avx/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/znx.rs
@@ -209,8 +209,29 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Avx {
 
 impl ZnxExtractDigitAddMul for NTT4x30Avx {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe {
+            crate::znx_avx::znx_extract_digit_mul_avx(base2k, lsh, res, src);
+        }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe { znx_extract_digit_addmul_avx(base2k, lsh, res, src) }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        unsafe {
+            crate::znx_avx::znx_extract_digit_addmul_normalize_avx::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+        }
     }
 }
 

--- a/poulpy-cpu-avx/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/znx.rs
@@ -209,15 +209,17 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Avx {
 
 impl ZnxExtractDigitAddMul for NTT4x30Avx {
     #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe { znx_extract_digit_addmul_avx(base2k, lsh, res, src) }
+    }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Avx {
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx::znx_extract_digit_mul_avx(base2k, lsh, res, src);
         }
-    }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        unsafe { znx_extract_digit_addmul_avx(base2k, lsh, res, src) }
     }
 
     #[inline(always)]

--- a/poulpy-cpu-avx/src/znx_avx/normalization.rs
+++ b/poulpy-cpu-avx/src/znx_avx/normalization.rs
@@ -64,15 +64,12 @@ unsafe fn get_carry_avx(
 
 /// # Safety
 /// Caller must ensure the CPU supports AVX2 (e.g., via `is_x86_feature_detected!("avx2")`);
-/// `res` and `src` must have the same length and must not alias.
+/// Slice lengths are checked before accessing coefficients.
 #[cfg(target_arch = "x86_64")]
 #[inline]
 #[target_feature(enable = "avx2")]
 pub fn znx_extract_digit_addmul_impl_avx<const OVERWRITE: bool>(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-    #[cfg(debug_assertions)]
-    {
-        assert_eq!(res.len(), src.len());
-    }
+    assert!(src.len() >= res.len());
 
     use std::arch::x86_64::{
         __m256i, _mm256_add_epi64, _mm256_loadu_si256, _mm256_set1_epi64x, _mm256_sllv_epi64, _mm256_storeu_si256,
@@ -993,7 +990,7 @@ pub fn znx_normalize_final_step_sub_avx(base2k: usize, lsh: usize, x: &mut [i64]
 }
 
 /// # Safety
-/// Requires AVX2, disjoint equal-length slices and representable accumulated sums.
+/// Requires AVX2 and representable accumulated sums.
 #[inline]
 #[target_feature(enable = "avx2")]
 pub fn znx_extract_digit_addmul_normalize_avx<const OVERWRITE: bool>(
@@ -1004,8 +1001,8 @@ pub fn znx_extract_digit_addmul_normalize_avx<const OVERWRITE: bool>(
     src: &mut [i64],
     carry: &mut [i64],
 ) {
-    debug_assert_eq!(res.len(), src.len());
-    debug_assert!(carry.len() >= res.len());
+    assert!(src.len() >= res.len());
+    assert!(carry.len() >= res.len());
     use std::arch::x86_64::{_mm256_loadu_si256, _mm256_set1_epi64x, _mm256_sllv_epi64, _mm256_storeu_si256};
     let end = res.len() / 4 * 4;
     unsafe {

--- a/poulpy-cpu-avx/src/znx_avx/normalization.rs
+++ b/poulpy-cpu-avx/src/znx_avx/normalization.rs
@@ -39,7 +39,7 @@ fn get_digit_avx(x: __m256i, mask_k: __m256i, sign_k: __m256i) -> __m256i {
 }
 
 /// AVX2 get_carry using precomputed shift and topmask:
-/// carry = (x - digit) >>_arith k
+/// carry = (x - digit) >>_arith k; the subtraction must be representable.
 ///
 /// # Safety
 /// Caller must ensure the CPU supports AVX2 (e.g., via `is_x86_feature_detected!("avx2")`);
@@ -68,7 +68,7 @@ unsafe fn get_carry_avx(
 #[cfg(target_arch = "x86_64")]
 #[inline]
 #[target_feature(enable = "avx2")]
-pub fn znx_extract_digit_addmul_avx(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+pub fn znx_extract_digit_addmul_impl_avx<const OVERWRITE: bool>(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
     #[cfg(debug_assertions)]
     {
         assert_eq!(res.len(), src.len());
@@ -96,9 +96,12 @@ pub fn znx_extract_digit_addmul_avx(base2k: usize, lsh: usize, res: &mut [i64], 
             let carry_256: __m256i = get_carry_avx(sv, digit_256, base2k_vec, top_mask);
 
             // res += (digit << lsh)
-            let rv: __m256i = _mm256_loadu_si256(rr);
             let madd: __m256i = _mm256_sllv_epi64(digit_256, lsh_v);
-            let sum: __m256i = _mm256_add_epi64(rv, madd);
+            let sum = if OVERWRITE {
+                madd
+            } else {
+                _mm256_add_epi64(_mm256_loadu_si256(rr), madd)
+            };
 
             _mm256_storeu_si256(rr, sum);
             _mm256_storeu_si256(ss, carry_256);
@@ -110,11 +113,27 @@ pub fn znx_extract_digit_addmul_avx(base2k: usize, lsh: usize, res: &mut [i64], 
 
     // tail (scalar)
     if !n.is_multiple_of(4) {
-        use poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_ref;
+        use poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_impl_ref;
 
         let off: usize = span << 2;
-        znx_extract_digit_addmul_ref(base2k, lsh, &mut res[off..], &mut src[off..]);
+        znx_extract_digit_addmul_impl_ref::<OVERWRITE>(base2k, lsh, &mut res[off..], &mut src[off..]);
     }
+}
+
+/// # Safety
+/// Requires compatible slice lengths and the backend ISA.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub fn znx_extract_digit_addmul_avx(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    znx_extract_digit_addmul_impl_avx::<false>(base2k, lsh, res, src);
+}
+
+/// # Safety
+/// Requires compatible slice lengths and the backend ISA.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub fn znx_extract_digit_mul_avx(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    znx_extract_digit_addmul_impl_avx::<true>(base2k, lsh, res, src);
 }
 
 /// # Safety
@@ -973,7 +992,71 @@ pub fn znx_normalize_final_step_sub_avx(base2k: usize, lsh: usize, x: &mut [i64]
     }
 }
 
+/// # Safety
+/// Requires AVX2, disjoint equal-length slices and representable accumulated sums.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub fn znx_extract_digit_addmul_normalize_avx<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i64],
+    carry: &mut [i64],
+) {
+    debug_assert_eq!(res.len(), src.len());
+    debug_assert!(carry.len() >= res.len());
+    use std::arch::x86_64::{_mm256_loadu_si256, _mm256_set1_epi64x, _mm256_sllv_epi64, _mm256_storeu_si256};
+    let end = res.len() / 4 * 4;
+    unsafe {
+        let (mask, sign, shift, top) = normalize_consts_avx(base2k);
+        let (res_mask, res_sign, res_shift, res_top) = normalize_consts_avx(res_base2k);
+        let scale = _mm256_set1_epi64x(lsh as i64);
+        for i in (0..end).step_by(4) {
+            let source = _mm256_loadu_si256(src.as_ptr().add(i).cast());
+            let digit = get_digit_avx(source, mask, sign);
+            let quotient = get_carry_avx(source, digit, shift, top);
+            let partial = if OVERWRITE {
+                _mm256_sllv_epi64(digit, scale)
+            } else {
+                _mm256_add_epi64(
+                    _mm256_loadu_si256(res.as_ptr().add(i).cast()),
+                    _mm256_sllv_epi64(digit, scale),
+                )
+            };
+            let sum = _mm256_add_epi64(partial, _mm256_loadu_si256(carry.as_ptr().add(i).cast()));
+            let output = get_digit_avx(sum, res_mask, res_sign);
+            let output_carry = get_carry_avx(sum, output, res_shift, res_top);
+            _mm256_storeu_si256(src.as_mut_ptr().add(i).cast(), quotient);
+            _mm256_storeu_si256(res.as_mut_ptr().add(i).cast(), output);
+            _mm256_storeu_si256(carry.as_mut_ptr().add(i).cast(), output_carry);
+        }
+    }
+    poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(
+        base2k,
+        lsh,
+        res_base2k,
+        &mut res[end..],
+        &mut src[end..],
+        &mut carry[end..],
+    );
+}
+
 mod tests {
+    #[test]
+    fn test_normalization_kernels_bounded_inputs() {
+        if !std::is_x86_feature_detected!("avx2") {
+            return;
+        }
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx>();
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx>();
+        #[cfg(feature = "enable-rayon")]
+        {
+            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64AvxRayon>();
+            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30AvxRayon>();
+        }
+    }
+
     use poulpy_cpu_ref::reference::znx::{
         get_carry_i64, get_digit_i64, znx_extract_digit_addmul_ref, znx_normalize_digit_ref, znx_normalize_final_step_assign_ref,
         znx_normalize_final_step_ref, znx_normalize_first_step_assign_ref, znx_normalize_first_step_ref,

--- a/poulpy-cpu-avx/src/znx_avx/normalization.rs
+++ b/poulpy-cpu-avx/src/znx_avx/normalization.rs
@@ -1045,12 +1045,12 @@ mod tests {
         if !std::is_x86_feature_detected!("avx2") {
             return;
         }
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx>();
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx>();
+        poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx>();
+        poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx>();
         #[cfg(feature = "enable-rayon")]
         {
-            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64AvxRayon>();
-            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30AvxRayon>();
+            poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::FFT64AvxRayon>();
+            poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30AvxRayon>();
         }
     }
 

--- a/poulpy-cpu-avx512/src/fft64/module.rs
+++ b/poulpy-cpu-avx512/src/fft64/module.rs
@@ -449,16 +449,18 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Avx512 {
 
 impl ZnxExtractDigitAddMul for FFT64Avx512 {
     #[inline(always)]
-    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        unsafe {
-            crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);
-        }
-    }
-
-    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             znx_extract_digit_addmul_avx512(base2k, lsh, res, src);
+        }
+    }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for FFT64Avx512 {
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe {
+            crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);
         }
     }
 

--- a/poulpy-cpu-avx512/src/fft64/module.rs
+++ b/poulpy-cpu-avx512/src/fft64/module.rs
@@ -449,9 +449,30 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Avx512 {
 
 impl ZnxExtractDigitAddMul for FFT64Avx512 {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe {
+            crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);
+        }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             znx_extract_digit_addmul_avx512(base2k, lsh, res, src);
+        }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        unsafe {
+            crate::znx_avx512::znx_extract_digit_addmul_normalize_avx512::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
         }
     }
 }

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/rayon.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/rayon.rs
@@ -247,10 +247,14 @@ impl ZnxExtractDigitAddMul for NTT3x42IfmaRayon {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT3x42Ifma as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
     }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT3x42IfmaRayon {
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        <NTT3x42Ifma as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+        <NTT3x42Ifma as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }
+
     #[inline(always)]
     fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
         base2k: usize,
@@ -260,7 +264,7 @@ impl ZnxExtractDigitAddMul for NTT3x42IfmaRayon {
         src: &mut [i64],
         carry: &mut [i64],
     ) {
-        <NTT3x42Ifma as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+        <NTT3x42Ifma as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
             base2k, lsh, res_base2k, res, src, carry,
         );
     }
@@ -339,6 +343,25 @@ impl I128BigOps for NTT3x42IfmaRayon {
 }
 
 impl I128NormalizeOps for NTT3x42IfmaRayon {
+    const FUSE_NORMALIZE: bool = <NTT3x42Ifma as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT3x42Ifma as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT3x42Ifma as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        )
+    }
+
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         <NTT3x42Ifma as I128NormalizeOps>::nfc_middle_step(base2k, lsh, res, a, carry)
@@ -1467,27 +1490,6 @@ impl poulpy_cpu_rayon::RayonTuning for NTT3x42IfmaRayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
-}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT3x42IfmaRayon {
-    const FUSE_NORMALIZE: bool = <NTT3x42Ifma as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
-
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        <NTT3x42Ifma as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        <NTT3x42Ifma as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
-            base2k, lsh, res_base2k, res, src, carry,
-        )
-    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/rayon.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/rayon.rs
@@ -242,10 +242,29 @@ forward_znx!(
     ZnxNormalizeFinalStepAssign,
     znx_normalize_final_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64])
 );
-forward_znx!(
-    ZnxExtractDigitAddMul,
-    znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64])
-);
+impl ZnxExtractDigitAddMul for NTT3x42IfmaRayon {
+    #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT3x42Ifma as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT3x42Ifma as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <NTT3x42Ifma as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
+    }
+}
 forward_znx!(ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
 
 unsafe impl HalModuleImpl<NTT3x42IfmaRayon> for NTT3x42IfmaRayon {
@@ -1448,6 +1467,27 @@ impl poulpy_cpu_rayon::RayonTuning for NTT3x42IfmaRayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
+}
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT3x42IfmaRayon {
+    const FUSE_NORMALIZE: bool = <NTT3x42Ifma as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT3x42Ifma as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT3x42Ifma as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
@@ -154,3 +154,24 @@ impl I128NormalizeOps for NTT3x42Ifma {
         }
     }
 }
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT3x42Ifma {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
+        }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
+        }
+    }
+}

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
@@ -157,6 +157,7 @@ impl I128NormalizeOps for NTT3x42Ifma {
 
 impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT3x42Ifma {
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
         unsafe {
             crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
         }
@@ -170,6 +171,8 @@ impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT3x42Ifma {
         src: &mut [i128],
         carry: &mut [i128],
     ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
         unsafe {
             crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
         }

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
@@ -1,6 +1,6 @@
 //! Large-coefficient (i128) ring element vector support for [`NTT3x42Ifma`](super::NTT3x42Ifma).
 //!
-//! The shared `poulpy-hal` NTT4x30 defaults rely on backend-provided `I128BigOps`
+//! The shared `poulpy-cpu-ref` NTT4x30 defaults rely on backend-provided `I128BigOps`
 //! and `I128NormalizeOps` hooks for vectorized i128 operations. The kernels themselves
 //! live in [`crate::vec_znx_big_avx512`] and are shared with [`NTT4x30Avx512`](crate::NTT4x30Avx512):
 //! both backends use an i128 `BigWord`, so the AVX-512F mask-form borrow propagation
@@ -97,6 +97,28 @@ impl BigWordHadamardProduct for NTT3x42Ifma {
 }
 
 impl I128NormalizeOps for NTT3x42Ifma {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
+        }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
+        }
+    }
+
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         if base2k <= 64 && res.len() >= 8 {
@@ -151,30 +173,6 @@ impl I128NormalizeOps for NTT3x42Ifma {
             nfc_final_step_sub_assign_scalar(base2k, lsh, res, carry);
         } else {
             nfc_final_step_add_assign_scalar(base2k, lsh, res, carry);
-        }
-    }
-}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT3x42Ifma {
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        assert!(src.len() >= res.len());
-        unsafe {
-            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
-        }
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        assert!(src.len() >= res.len());
-        assert!(carry.len() >= res.len());
-        unsafe {
-            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
         }
     }
 }

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/znx.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/znx.rs
@@ -210,15 +210,17 @@ impl ZnxNormalizeMiddleStepAssign for NTT3x42Ifma {
 
 impl ZnxExtractDigitAddMul for NTT3x42Ifma {
     #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe { znx_extract_digit_addmul_avx512(base2k, lsh, res, src) }
+    }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT3x42Ifma {
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);
         }
-    }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        unsafe { znx_extract_digit_addmul_avx512(base2k, lsh, res, src) }
     }
 
     #[inline(always)]

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/znx.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/znx.rs
@@ -210,8 +210,29 @@ impl ZnxNormalizeMiddleStepAssign for NTT3x42Ifma {
 
 impl ZnxExtractDigitAddMul for NTT3x42Ifma {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe {
+            crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);
+        }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe { znx_extract_digit_addmul_avx512(base2k, lsh, res, src) }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        unsafe {
+            crate::znx_avx512::znx_extract_digit_addmul_normalize_avx512::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+        }
     }
 }
 

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon.rs
@@ -244,10 +244,16 @@ impl ZnxExtractDigitAddMul for NTT4x30Avx512Rayon {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT4x30Avx512 as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
     }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Avx512Rayon {
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        <NTT4x30Avx512 as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+        <NTT4x30Avx512 as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(
+            base2k, lsh, res, src,
+        );
     }
+
     #[inline(always)]
     fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
         base2k: usize,
@@ -257,9 +263,9 @@ impl ZnxExtractDigitAddMul for NTT4x30Avx512Rayon {
         src: &mut [i64],
         carry: &mut [i64],
     ) {
-        <NTT4x30Avx512 as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
-            base2k, lsh, res_base2k, res, src, carry,
-        );
+        <NTT4x30Avx512 as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_addmul_normalize::<
+            OVERWRITE,
+        >(base2k, lsh, res_base2k, res, src, carry);
     }
 }
 forward_znx!(ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
@@ -408,6 +414,25 @@ impl I128BigOps for NTT4x30Avx512Rayon {
 }
 
 impl I128NormalizeOps for NTT4x30Avx512Rayon {
+    const FUSE_NORMALIZE: bool = <NTT4x30Avx512 as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Avx512 as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_mul_i128(base2k, lsh, res, src)
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Avx512 as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::znx_extract_digit_addmul_normalize_i128::<
+            OVERWRITE,
+        >(base2k, lsh, res_base2k, res, src, carry)
+    }
+
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         <NTT4x30Avx512 as I128NormalizeOps>::nfc_middle_step(base2k, lsh, res, a, carry)
     }
@@ -1616,29 +1641,6 @@ impl poulpy_cpu_rayon::RayonTuning for NTT4x30Avx512Rayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
-}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx512Rayon {
-    const FUSE_NORMALIZE: bool = <NTT4x30Avx512 as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
-
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        <NTT4x30Avx512 as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(
-            base2k, lsh, res, src,
-        )
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        <NTT4x30Avx512 as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<
-            OVERWRITE,
-        >(base2k, lsh, res_base2k, res, src, carry)
-    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon.rs
@@ -239,7 +239,29 @@ forward_znx!(ZnxNormalizeMiddleStepAssign, znx_normalize_middle_step_assign(base
 forward_znx!(ZnxNormalizeMiddleStepSub, znx_normalize_middle_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 forward_znx!(ZnxNormalizeFinalStepSub, znx_normalize_final_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 forward_znx!(ZnxNormalizeFinalStepAssign, znx_normalize_final_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64]));
-forward_znx!(ZnxExtractDigitAddMul, znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]));
+impl ZnxExtractDigitAddMul for NTT4x30Avx512Rayon {
+    #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT4x30Avx512 as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <NTT4x30Avx512 as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <NTT4x30Avx512 as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
+    }
+}
 forward_znx!(ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
 
 impl NttDFTExecute<NttTable<Primes30>> for NTT4x30Avx512Rayon {
@@ -1594,6 +1616,29 @@ impl poulpy_cpu_rayon::RayonTuning for NTT4x30Avx512Rayon {
     const COEFF_MIN_LEN: usize = 1 << 15;
     const COEFF_MIN_TASK: usize = 1 << 13;
     const NORMALIZE_MIN_TASK: usize = 1 << 12;
+}
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx512Rayon {
+    const FUSE_NORMALIZE: bool = <NTT4x30Avx512 as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::FUSE_NORMALIZE;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Avx512 as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_mul_i128(
+            base2k, lsh, res, src,
+        )
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Avx512 as poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<
+            OVERWRITE,
+        >(base2k, lsh, res_base2k, res, src, carry)
+    }
 }
 
 #[cfg(test)]

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
@@ -155,3 +155,24 @@ impl I128NormalizeOps for NTT4x30Avx512 {
         }
     }
 }
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx512 {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
+        }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
+        }
+    }
+}

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
@@ -158,6 +158,7 @@ impl I128NormalizeOps for NTT4x30Avx512 {
 
 impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx512 {
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
         unsafe {
             crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
         }
@@ -171,6 +172,8 @@ impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx512 {
         src: &mut [i128],
         carry: &mut [i128],
     ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
         unsafe {
             crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
         }

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
@@ -1,6 +1,6 @@
 //! Large-coefficient (i128) ring element vector support for [`NTT4x30Avx512`](super::NTT4x30Avx512).
 //!
-//! The shared `poulpy-hal` NTT4x30 defaults rely on backend-provided `I128BigOps`
+//! The shared `poulpy-cpu-ref` NTT4x30 defaults rely on backend-provided `I128BigOps`
 //! and `I128NormalizeOps` hooks for vectorized i128 operations. The kernels themselves
 //! live in [`crate::vec_znx_big_avx512`] and operate on **4 i128 per `__m512i`**
 //! (the 256-bit AVX backend handles 2 i128 per `__m256i`). Mask-form compares
@@ -98,6 +98,28 @@ impl BigWordHadamardProduct for NTT4x30Avx512 {
 }
 
 impl I128NormalizeOps for NTT4x30Avx512 {
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
+        }
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        assert!(src.len() >= res.len());
+        assert!(carry.len() >= res.len());
+        unsafe {
+            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
+        }
+    }
+
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
         if base2k <= 64 && res.len() >= 8 {
@@ -152,30 +174,6 @@ impl I128NormalizeOps for NTT4x30Avx512 {
             nfc_final_step_sub_assign_scalar(base2k, lsh, res, carry);
         } else {
             nfc_final_step_add_assign_scalar(base2k, lsh, res, carry);
-        }
-    }
-}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Avx512 {
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        assert!(src.len() >= res.len());
-        unsafe {
-            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
-        }
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        assert!(src.len() >= res.len());
-        assert!(carry.len() >= res.len());
-        unsafe {
-            crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<OVERWRITE, true>(base2k, lsh, res_base2k, res, src, carry)
         }
     }
 }

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/znx.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/znx.rs
@@ -211,8 +211,29 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Avx512 {
 
 impl ZnxExtractDigitAddMul for NTT4x30Avx512 {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe {
+            crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);
+        }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe { znx_extract_digit_addmul_avx512(base2k, lsh, res, src) }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        unsafe {
+            crate::znx_avx512::znx_extract_digit_addmul_normalize_avx512::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+        }
     }
 }
 

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/znx.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/znx.rs
@@ -211,15 +211,17 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Avx512 {
 
 impl ZnxExtractDigitAddMul for NTT4x30Avx512 {
     #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        unsafe { znx_extract_digit_addmul_avx512(base2k, lsh, res, src) }
+    }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Avx512 {
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);
         }
-    }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        unsafe { znx_extract_digit_addmul_avx512(base2k, lsh, res, src) }
     }
 
     #[inline(always)]

--- a/poulpy-cpu-avx512/src/vec_znx_big_avx512.rs
+++ b/poulpy-cpu-avx512/src/vec_znx_big_avx512.rs
@@ -1272,11 +1272,11 @@ pub(super) unsafe fn nfc_extract_normalize_avx512<const OVERWRITE: bool, const F
 ) {
     if base2k >= 64 || res_base2k >= 64 {
         if FINALIZE {
-            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k, lsh, res_base2k, res, src, carry,
             );
         } else {
-            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
         }
         return;
     }
@@ -1320,7 +1320,7 @@ pub(super) unsafe fn nfc_extract_normalize_avx512<const OVERWRITE: bool, const F
             }
         }
         if FINALIZE {
-            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k,
                 lsh,
                 res_base2k,
@@ -1329,7 +1329,7 @@ pub(super) unsafe fn nfc_extract_normalize_avx512<const OVERWRITE: bool, const F
                 &mut carry[end..],
             );
         } else {
-            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
         }
     }
 }
@@ -1509,16 +1509,16 @@ mod tests {
     }
     #[test]
     fn nfc_fused_matches_scalar() {
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx512>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx512>();
         #[cfg(feature = "enable-rayon")]
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx512Rayon>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx512Rayon>();
     }
 
     #[test]
     #[cfg(feature = "enable-ifma")]
     fn nfc_ifma_fused_matches_scalar() {
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT3x42Ifma>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT3x42Ifma>();
         #[cfg(feature = "enable-rayon")]
-        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT3x42IfmaRayon>();
+        poulpy_cpu_ref::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT3x42IfmaRayon>();
     }
 }

--- a/poulpy-cpu-avx512/src/vec_znx_big_avx512.rs
+++ b/poulpy-cpu-avx512/src/vec_znx_big_avx512.rs
@@ -196,7 +196,6 @@ const INTERLEAVE_HI: [i64; 8] = [4, 12, 5, 13, 6, 14, 7, 15]; // second 4 pairs
 /// Fields with `__m128i` type are variable shift counts for `_mm512_srl/sll_epi64`.
 /// Fields with `__m128i` type (sra) are shift counts for `_mm512_sra_epi64`.
 struct NfcShifts512 {
-    lsh_is_zero: bool,
     /// `_mm_cvtsi64_si128((64 - base2k_lsh) as i64)` -- left-shift for digit extraction.
     sll_b2klsh: __m128i,
     /// `_mm_cvtsi64_si128((64 - base2k_lsh) as i64)` -- arithmetic right-shift count for digit extraction.
@@ -227,7 +226,6 @@ impl NfcShifts512 {
         unsafe {
             let b2klsh = base2k - lsh;
             Self {
-                lsh_is_zero: lsh == 0,
                 sll_b2klsh: _mm_cvtsi64_si128((64 - b2klsh) as i64),
                 sra_b2klsh: _mm_cvtsi64_si128((64 - b2klsh) as i64),
                 srl_b2klsh: _mm_cvtsi64_si128(b2klsh as i64),
@@ -259,22 +257,7 @@ unsafe fn nfc_middle_chunk_512(
     hi_c: __m512i,
 ) -> (__m512i, __m512i, __m512i) {
     unsafe {
-        if s.lsh_is_zero {
-            let lo_sum = _mm512_add_epi64(lo_a, lo_c);
-            let carry_mask = _mm512_cmp_epu64_mask(lo_sum, lo_a, _MM_CMPINT_LT);
-            let carry = _mm512_maskz_set1_epi64(carry_mask, 1);
-            let hi_sum = _mm512_add_epi64(_mm512_add_epi64(hi_a, hi_c), carry);
-            let lo_out = _mm512_sra_epi64(_mm512_sll_epi64(lo_sum, s.sll_b2k), s.sra_b2k);
-            let hi_out = _mm512_sra_epi64(lo_out, s.sra_63);
-            let diff_lo = _mm512_sub_epi64(lo_sum, lo_out);
-            let borrow_mask = _mm512_cmp_epu64_mask(lo_out, lo_sum, _MM_CMPINT_NLE);
-            let borrow = _mm512_maskz_set1_epi64(borrow_mask, 1);
-            let diff_hi = _mm512_sub_epi64(_mm512_sub_epi64(hi_sum, hi_out), borrow);
-            let new_lo_c = _mm512_or_si512(_mm512_srl_epi64(diff_lo, s.srl_b2k), _mm512_sll_epi64(diff_hi, s.sll_b2k));
-            let new_hi_c = _mm512_sra_epi64(diff_hi, s.sra_b2k_val);
-            return (lo_out, new_lo_c, new_hi_c);
-        }
-
+        // Extract before adding carry, since the positive bounded endpoints can sum to 2^127.
         // digit = get_digit_i128(base2k_lsh, a)
         let lo_dig = _mm512_sra_epi64(_mm512_sll_epi64(lo_a, s.sll_b2klsh), s.sra_b2klsh);
         let hi_dig = _mm512_sra_epi64(lo_dig, s.sra_63);
@@ -358,6 +341,11 @@ unsafe fn nfc_final_chunk_512(s: &NfcShifts512, lo_a: __m512i, lo_c: __m512i) ->
 /// Requires AVX-512F.  `res`, `a`, `carry` must each have at least `n` elements.
 #[target_feature(enable = "avx512f")]
 pub(super) unsafe fn nfc_middle_step_avx512(base2k: u32, lsh: u32, n: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+    if base2k >= 64 {
+        nfc_middle_step_scalar(base2k as usize, lsh as usize, res, a, carry);
+        return;
+    }
+
     unsafe {
         let s = NfcShifts512::new(base2k, lsh);
         let a_ptr = a.as_ptr() as *const __m512i;
@@ -415,6 +403,11 @@ pub(super) unsafe fn nfc_middle_step_add_assign_avx512(
     a: &[i128],
     carry: &mut [i128],
 ) {
+    if base2k >= 64 {
+        nfc_middle_step_add_assign_scalar(base2k as usize, lsh as usize, res, a, carry);
+        return;
+    }
+
     unsafe {
         let s = NfcShifts512::new(base2k, lsh);
         let a_ptr = a.as_ptr() as *const __m512i;
@@ -472,6 +465,11 @@ pub(super) unsafe fn nfc_middle_step_sub_assign_avx512(
     a: &[i128],
     carry: &mut [i128],
 ) {
+    if base2k >= 64 {
+        nfc_middle_step_sub_assign_scalar(base2k as usize, lsh as usize, res, a, carry);
+        return;
+    }
+
     unsafe {
         let s = NfcShifts512::new(base2k, lsh);
         let a_ptr = a.as_ptr() as *const __m512i;
@@ -529,6 +527,11 @@ pub(super) unsafe fn nfc_middle_step_sub_assign_avx512(
 /// Requires AVX-512F.
 #[target_feature(enable = "avx512f")]
 pub(super) unsafe fn nfc_middle_step_assign_avx512(base2k: u32, lsh: u32, n: usize, res: &mut [i64], carry: &mut [i128]) {
+    if base2k >= 64 {
+        nfc_middle_step_assign_scalar(base2k as usize, lsh as usize, res, carry);
+        return;
+    }
+
     unsafe {
         let s = NfcShifts512::new(base2k, lsh);
         let c_ptr = carry.as_mut_ptr() as *mut __m512i;
@@ -1258,6 +1261,79 @@ pub(super) unsafe fn vi128_neg_from_small_avx512(n: usize, res: &mut [i128], a: 
 // Tests
 // ──────────────────────────────────────────────────────────────────────────────
 
+#[target_feature(enable = "avx512f")]
+pub(super) unsafe fn nfc_extract_normalize_avx512<const OVERWRITE: bool, const FINALIZE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i128],
+    carry: &mut [i128],
+) {
+    if base2k >= 64 || res_base2k >= 64 {
+        if FINALIZE {
+            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+                base2k, lsh, res_base2k, res, src, carry,
+            );
+        } else {
+            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+        }
+        return;
+    }
+    unsafe {
+        let source_shifts = NfcShifts512::new(base2k as u32, 0);
+        let result_shifts = NfcShifts512::new(res_base2k as u32, 0);
+        let scale = _mm_cvtsi64_si128(lsh as i64);
+        let zero = _mm512_setzero_si512();
+        let dl = _mm512_loadu_si512(DEINTERLEAVE_LO.as_ptr().cast::<__m512i>());
+        let dh = _mm512_loadu_si512(DEINTERLEAVE_HI.as_ptr().cast::<__m512i>());
+        let il = _mm512_loadu_si512(INTERLEAVE_LO.as_ptr().cast::<__m512i>());
+        let ih = _mm512_loadu_si512(INTERLEAVE_HI.as_ptr().cast::<__m512i>());
+        let load = |ptr: *const i128| {
+            let x0 = _mm512_loadu_si512(ptr.cast::<__m512i>());
+            let x1 = _mm512_loadu_si512(ptr.cast::<__m512i>().add(1));
+            (_mm512_permutex2var_epi64(x0, dl, x1), _mm512_permutex2var_epi64(x0, dh, x1))
+        };
+        let store = |ptr: *mut i128, lo, hi| {
+            _mm512_storeu_si512(ptr.cast::<__m512i>(), _mm512_permutex2var_epi64(lo, il, hi));
+            _mm512_storeu_si512(ptr.cast::<__m512i>().add(1), _mm512_permutex2var_epi64(lo, ih, hi));
+        };
+        let end = res.len() / 8 * 8;
+        for i in (0..end).step_by(8) {
+            let (a_lo, a_hi) = load(src.as_ptr().add(i));
+            let (digit, next_lo, next_hi) = nfc_middle_chunk_512(&source_shifts, a_lo, a_hi, zero, zero);
+            store(src.as_mut_ptr().add(i), next_lo, next_hi);
+            let initial = if OVERWRITE {
+                zero
+            } else {
+                _mm512_loadu_si512(res.as_ptr().add(i).cast::<__m512i>())
+            };
+            let accum = _mm512_add_epi64(initial, _mm512_sll_epi64(digit, scale));
+            if FINALIZE {
+                let (c_lo, c_hi) = load(carry.as_ptr().add(i));
+                let (out, next_lo, next_hi) =
+                    nfc_middle_chunk_512(&result_shifts, accum, _mm512_srai_epi64(accum, 63), c_lo, c_hi);
+                _mm512_storeu_si512(res.as_mut_ptr().add(i).cast::<__m512i>(), out);
+                store(carry.as_mut_ptr().add(i), next_lo, next_hi);
+            } else {
+                _mm512_storeu_si512(res.as_mut_ptr().add(i).cast::<__m512i>(), accum);
+            }
+        }
+        if FINALIZE {
+            poulpy_hal::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
+                base2k,
+                lsh,
+                res_base2k,
+                &mut res[end..],
+                &mut src[end..],
+                &mut carry[end..],
+            );
+        } else {
+            poulpy_hal::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+        }
+    }
+}
+
 #[cfg(all(test, target_feature = "avx512f"))]
 mod tests {
     use super::{
@@ -1332,62 +1408,117 @@ mod tests {
     }
 
     #[test]
-    fn nfc_middle_step_avx512_vs_scalar() {
-        let n = 64usize;
-        let base2k = 16usize;
-        let lsh = 0usize;
-        let a = i128_data(n, 37i128);
-        let carry_init: Vec<i128> = (0..n).map(|i| (i as i128 * 3) % (1i128 << 20)).collect();
+    fn nfc_bounded_inputs_match_scalar() {
+        let bound = 1i128 << 126;
+        let idft_bound = 657821220234910467805273421263929344i128;
+        for base2k in 1..=63 {
+            let half = 1i128 << (base2k - 1);
+            let mut a = vec![
+                -bound,
+                bound,
+                0,
+                1,
+                -1,
+                half,
+                -half,
+                half - 1,
+                -half - 1,
+                i64::MIN as i128,
+                i64::MAX as i128,
+                idft_bound,
+                -idft_bound,
+            ];
+            let mut state = 0x123456789abcdef0u128;
+            for _ in 0..10 {
+                state ^= state << 17;
+                state ^= state >> 29;
+                state ^= state << 43;
+                a.push((state as i128) >> 1);
+            }
+            let n = a.len();
+            for lsh in 0..base2k {
+                for round in 0..3 {
+                    let carry: Vec<_> = (0..n).map(|i| a[(i + round) % n]).collect();
+                    let initial: Vec<_> = a.iter().map(|&v| (v as i64) >> 1).collect();
+                    let mut want = initial.clone();
+                    let mut got = initial.clone();
+                    let mut want_carry = carry.clone();
+                    let mut got_carry = carry.clone();
+                    nfc_middle_step_scalar(base2k, lsh, &mut want, &a, &mut want_carry);
+                    if lsh == 0 && round == 0 {
+                        assert_eq!((want[1], want_carry[1]), (0, bound >> (base2k - 1)));
+                    }
+                    unsafe { nfc_middle_step_avx512(base2k as u32, lsh as u32, n, &mut got, &a, &mut got_carry) };
+                    assert_eq!(
+                        (&got, &got_carry),
+                        (&want, &want_carry),
+                        "middle k={base2k} lsh={lsh} round={round}"
+                    );
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    nfc_middle_step_assign_scalar(base2k, lsh, &mut want, &mut want_carry);
+                    unsafe { nfc_middle_step_assign_avx512(base2k as u32, lsh as u32, n, &mut got, &mut got_carry) };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "assign k={base2k} lsh={lsh}");
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    nfc_final_step_assign_scalar(base2k, lsh, &mut want, &mut want_carry);
+                    unsafe { nfc_final_step_assign_avx512(base2k as u32, lsh as u32, n, &mut got, &mut got_carry) };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "final k={base2k} lsh={lsh}");
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    super::nfc_middle_step_add_assign_scalar(base2k, lsh, &mut want, &a, &mut want_carry);
+                    unsafe {
+                        super::nfc_middle_step_add_assign_avx512(base2k as u32, lsh as u32, n, &mut got, &a, &mut got_carry)
+                    };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "middle add k={base2k} lsh={lsh}");
 
-        let mut res_avx = vec![0i64; n];
-        let mut carry_avx = carry_init.clone();
-        let mut res_ref = vec![0i64; n];
-        let mut carry_ref = carry_init.clone();
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    super::nfc_middle_step_sub_assign_scalar(base2k, lsh, &mut want, &a, &mut want_carry);
+                    unsafe {
+                        super::nfc_middle_step_sub_assign_avx512(base2k as u32, lsh as u32, n, &mut got, &a, &mut got_carry)
+                    };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "middle sub k={base2k} lsh={lsh}");
 
-        unsafe { nfc_middle_step_avx512(base2k as u32, lsh as u32, n, &mut res_avx, &a, &mut carry_avx) };
-        nfc_middle_step_scalar(base2k, lsh, &mut res_ref, &a, &mut carry_ref);
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    super::nfc_final_step_add_assign_scalar(base2k, lsh, &mut want, &mut want_carry);
+                    unsafe { super::nfc_final_step_add_assign_avx512(base2k as u32, lsh as u32, n, &mut got, &mut got_carry) };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "final add k={base2k} lsh={lsh}");
 
-        assert_eq!(res_avx, res_ref, "nfc_middle_step res mismatch");
-        assert_eq!(carry_avx, carry_ref, "nfc_middle_step carry mismatch");
+                    want.clone_from(&initial);
+                    got.clone_from(&initial);
+                    want_carry.clone_from(&carry);
+                    got_carry.clone_from(&carry);
+                    super::nfc_final_step_sub_assign_scalar(base2k, lsh, &mut want, &mut want_carry);
+                    unsafe { super::nfc_final_step_sub_assign_avx512(base2k as u32, lsh as u32, n, &mut got, &mut got_carry) };
+                    assert_eq!((&got, &got_carry), (&want, &want_carry), "final sub k={base2k} lsh={lsh}");
+                }
+            }
+        }
+    }
+    #[test]
+    fn nfc_fused_matches_scalar() {
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx512>();
+        #[cfg(feature = "enable-rayon")]
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT4x30Avx512Rayon>();
     }
 
     #[test]
-    fn nfc_middle_step_assign_avx512_vs_scalar() {
-        let n = 64usize;
-        let base2k = 16usize;
-        let lsh = 8usize;
-        let init: Vec<i64> = (0..n).map(|i| (i as i64 * 5) % (1i64 << 20)).collect();
-        let carry_init: Vec<i128> = (0..n).map(|i| (i as i128 * 7) % (1i128 << 20)).collect();
-
-        let mut res_avx = init.clone();
-        let mut carry_avx = carry_init.clone();
-        let mut res_ref = init.clone();
-        let mut carry_ref = carry_init.clone();
-
-        unsafe { nfc_middle_step_assign_avx512(base2k as u32, lsh as u32, n, &mut res_avx, &mut carry_avx) };
-        nfc_middle_step_assign_scalar(base2k, lsh, &mut res_ref, &mut carry_ref);
-
-        assert_eq!(res_avx, res_ref, "nfc_middle_step_assign res mismatch");
-        assert_eq!(carry_avx, carry_ref, "nfc_middle_step_assign carry mismatch");
-    }
-
-    #[test]
-    fn nfc_final_step_assign_avx512_vs_scalar() {
-        let n = 64usize;
-        let base2k = 16usize;
-        let lsh = 0usize;
-        let init: Vec<i64> = (0..n).map(|i| (i as i64 * 3) % (1i64 << 20)).collect();
-        let carry_init: Vec<i128> = (0..n).map(|i| (i as i128 * 11) % (1i128 << 20)).collect();
-
-        let mut res_avx = init.clone();
-        let mut carry_avx = carry_init.clone();
-        let mut res_ref = init.clone();
-        let mut carry_ref = carry_init.clone();
-
-        unsafe { nfc_final_step_assign_avx512(base2k as u32, lsh as u32, n, &mut res_avx, &mut carry_avx) };
-        nfc_final_step_assign_scalar(base2k, lsh, &mut res_ref, &mut carry_ref);
-
-        assert_eq!(res_avx, res_ref, "nfc_final_step_assign res mismatch");
-        assert_eq!(carry_avx, carry_ref, "nfc_final_step_assign carry mismatch");
+    #[cfg(feature = "enable-ifma")]
+    fn nfc_ifma_fused_matches_scalar() {
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT3x42Ifma>();
+        #[cfg(feature = "enable-rayon")]
+        poulpy_hal::test_suite::normalization_i128::test_i128_normalize_fused::<crate::NTT3x42IfmaRayon>();
     }
 }

--- a/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
+++ b/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
@@ -33,7 +33,8 @@ unsafe fn get_digit_avx512(x: __m512i, mask_k: __m512i, sign_k: __m512i) -> __m5
     _mm512_sub_epi64(t, sign_k)
 }
 
-/// AVX-512 `get_carry`:  `carry = (x - digit) >>_arith k`.
+/// AVX-512 `get_carry`: `carry = (x - digit) >>_arith k`.
+/// The subtraction must be representable.
 ///
 /// Uses `_mm512_srav_epi64` for a native variable arithmetic right shift,
 /// replacing the 4-instruction workaround needed by AVX2.
@@ -52,7 +53,12 @@ unsafe fn get_carry_avx512(x: __m512i, digit: __m512i, base2k: __m512i) -> __m51
 /// `res += digit(src) << lsh;  src = carry(src)`
 #[inline]
 #[target_feature(enable = "avx512f")]
-pub unsafe fn znx_extract_digit_addmul_avx512(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+pub unsafe fn znx_extract_digit_addmul_impl_avx512<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res: &mut [i64],
+    src: &mut [i64],
+) {
     debug_assert_eq!(res.len(), src.len());
 
     use core::arch::x86_64::{_mm512_add_epi64, _mm512_loadu_si512, _mm512_set1_epi64, _mm512_sllv_epi64, _mm512_storeu_si512};
@@ -71,9 +77,12 @@ pub unsafe fn znx_extract_digit_addmul_avx512(base2k: usize, lsh: usize, res: &m
         let digit_512: __m512i = get_digit_avx512(sv, mask, sign);
         let carry_512: __m512i = get_carry_avx512(sv, digit_512, base2k_vec);
 
-        let rv: __m512i = _mm512_loadu_si512(rr as *const _);
         let madd: __m512i = _mm512_sllv_epi64(digit_512, lsh_v);
-        let sum: __m512i = _mm512_add_epi64(rv, madd);
+        let sum = if OVERWRITE {
+            madd
+        } else {
+            _mm512_add_epi64(_mm512_loadu_si512(rr as *const _), madd)
+        };
 
         _mm512_storeu_si512(rr, sum);
         _mm512_storeu_si512(ss, carry_512);
@@ -84,10 +93,30 @@ pub unsafe fn znx_extract_digit_addmul_avx512(base2k: usize, lsh: usize, res: &m
 
     // scalar tail
     if !n.is_multiple_of(8) {
-        use poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_ref;
+        use poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_impl_ref;
 
         let off: usize = span << 3;
-        znx_extract_digit_addmul_ref(base2k, lsh, &mut res[off..], &mut src[off..]);
+        znx_extract_digit_addmul_impl_ref::<OVERWRITE>(base2k, lsh, &mut res[off..], &mut src[off..]);
+    }
+}
+
+/// # Safety
+/// Requires compatible slice lengths and the backend ISA.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn znx_extract_digit_addmul_avx512(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    unsafe {
+        znx_extract_digit_addmul_impl_avx512::<false>(base2k, lsh, res, src);
+    }
+}
+
+/// # Safety
+/// Requires compatible slice lengths and the backend ISA.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn znx_extract_digit_mul_avx512(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    unsafe {
+        znx_extract_digit_addmul_impl_avx512::<true>(base2k, lsh, res, src);
     }
 }
 
@@ -843,12 +872,80 @@ pub unsafe fn znx_normalize_final_step_sub_avx512(base2k: usize, lsh: usize, x: 
     }
 }
 
+/// Extracts the completing subdigit and normalizes the destination in one pass.
+///
+/// # Safety
+/// Requires AVX-512F, disjoint equal-length slices and representable accumulated sums.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn znx_extract_digit_addmul_normalize_avx512<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i64],
+    carry: &mut [i64],
+) {
+    debug_assert_eq!(res.len(), src.len());
+    debug_assert!(carry.len() >= res.len());
+    use core::arch::x86_64::{_mm512_add_epi64, _mm512_loadu_si512, _mm512_set1_epi64, _mm512_sllv_epi64, _mm512_storeu_si512};
+    let end = res.len() / 8 * 8;
+    let (mask, sign, shift) = normalize_consts_avx512(base2k);
+    let (res_mask, res_sign, res_shift) = normalize_consts_avx512(res_base2k);
+    let scale = _mm512_set1_epi64(lsh as i64);
+    for i in (0..end).step_by(8) {
+        let source = _mm512_loadu_si512(src.as_ptr().add(i).cast());
+        let digit = get_digit_avx512(source, mask, sign);
+        let quotient = get_carry_avx512(source, digit, shift);
+        let partial = if OVERWRITE {
+            _mm512_sllv_epi64(digit, scale)
+        } else {
+            _mm512_add_epi64(
+                _mm512_loadu_si512(res.as_ptr().add(i).cast()),
+                _mm512_sllv_epi64(digit, scale),
+            )
+        };
+        let sum = _mm512_add_epi64(partial, _mm512_loadu_si512(carry.as_ptr().add(i).cast()));
+        let output = get_digit_avx512(sum, res_mask, res_sign);
+        let output_carry = get_carry_avx512(sum, output, res_shift);
+        _mm512_storeu_si512(src.as_mut_ptr().add(i).cast(), quotient);
+        _mm512_storeu_si512(res.as_mut_ptr().add(i).cast(), output);
+        _mm512_storeu_si512(carry.as_mut_ptr().add(i).cast(), output_carry);
+    }
+    poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(
+        base2k,
+        lsh,
+        res_base2k,
+        &mut res[end..],
+        &mut src[end..],
+        &mut carry[end..],
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_normalization_kernels_bounded_inputs() {
+        if !std::is_x86_feature_detected!("avx512f") {
+            return;
+        }
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx512>();
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx512>();
+        #[cfg(feature = "enable-ifma")]
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT3x42Ifma>();
+        #[cfg(feature = "enable-rayon")]
+        {
+            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx512Rayon>();
+            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx512Rayon>();
+            #[cfg(feature = "enable-ifma")]
+            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT3x42IfmaRayon>();
+        }
+    }
+
     use poulpy_cpu_ref::reference::znx::{
         get_carry_i64, get_digit_i64, znx_extract_digit_addmul_ref, znx_normalize_digit_ref, znx_normalize_final_step_assign_ref,
         znx_normalize_final_step_ref, znx_normalize_first_step_assign_ref, znx_normalize_first_step_ref,

--- a/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
+++ b/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
@@ -933,16 +933,16 @@ mod tests {
         if !std::is_x86_feature_detected!("avx512f") {
             return;
         }
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx512>();
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx512>();
+        poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx512>();
+        poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx512>();
         #[cfg(feature = "enable-ifma")]
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT3x42Ifma>();
+        poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT3x42Ifma>();
         #[cfg(feature = "enable-rayon")]
         {
-            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx512Rayon>();
-            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx512Rayon>();
+            poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::FFT64Avx512Rayon>();
+            poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Avx512Rayon>();
             #[cfg(feature = "enable-ifma")]
-            poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT3x42IfmaRayon>();
+            poulpy_cpu_ref::test_suite::normalization::test_normalization_kernels::<crate::NTT3x42IfmaRayon>();
         }
     }
 

--- a/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
+++ b/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
@@ -59,7 +59,7 @@ pub unsafe fn znx_extract_digit_addmul_impl_avx512<const OVERWRITE: bool>(
     res: &mut [i64],
     src: &mut [i64],
 ) {
-    debug_assert_eq!(res.len(), src.len());
+    assert!(src.len() >= res.len());
 
     use core::arch::x86_64::{_mm512_add_epi64, _mm512_loadu_si512, _mm512_set1_epi64, _mm512_sllv_epi64, _mm512_storeu_si512};
 
@@ -875,7 +875,7 @@ pub unsafe fn znx_normalize_final_step_sub_avx512(base2k: usize, lsh: usize, x: 
 /// Extracts the completing subdigit and normalizes the destination in one pass.
 ///
 /// # Safety
-/// Requires AVX-512F, disjoint equal-length slices and representable accumulated sums.
+/// Requires AVX-512F and representable accumulated sums.
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn znx_extract_digit_addmul_normalize_avx512<const OVERWRITE: bool>(
@@ -886,8 +886,8 @@ pub unsafe fn znx_extract_digit_addmul_normalize_avx512<const OVERWRITE: bool>(
     src: &mut [i64],
     carry: &mut [i64],
 ) {
-    debug_assert_eq!(res.len(), src.len());
-    debug_assert!(carry.len() >= res.len());
+    assert!(src.len() >= res.len());
+    assert!(carry.len() >= res.len());
     use core::arch::x86_64::{_mm512_add_epi64, _mm512_loadu_si512, _mm512_set1_epi64, _mm512_sllv_epi64, _mm512_storeu_si512};
     let end = res.len() / 8 * 8;
     let (mask, sign, shift) = normalize_consts_avx512(base2k);

--- a/poulpy-cpu-rayon/src/fft64.rs
+++ b/poulpy-cpu-rayon/src/fft64.rs
@@ -204,7 +204,23 @@ $crate::rayon_forward_znx!($rayon, $base, ZnxNormalizeMiddleStepAssign, znx_norm
 $crate::rayon_forward_znx!($rayon, $base, ZnxNormalizeMiddleStepSub, znx_normalize_middle_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 $crate::rayon_forward_znx!($rayon, $base, ZnxNormalizeFinalStepSub, znx_normalize_final_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]));
 $crate::rayon_forward_znx!($rayon, $base, ZnxNormalizeFinalStepAssign, znx_normalize_final_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64]));
-$crate::rayon_forward_znx!($rayon, $base, ZnxExtractDigitAddMul, znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]));
+impl ZnxExtractDigitAddMul for $rayon {
+    #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <$base as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <$base as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+    }
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize, lsh: usize, res_base2k: usize,
+        res: &mut [i64], src: &mut [i64], carry: &mut [i64],
+    ) {
+        <$base as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+    }
+}
 $crate::rayon_forward_znx!($rayon, $base, ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
 
 impl ReimFFTExecute<ReimFFTTable<f64>, f64> for $rayon {

--- a/poulpy-cpu-rayon/src/fft64.rs
+++ b/poulpy-cpu-rayon/src/fft64.rs
@@ -209,16 +209,20 @@ impl ZnxExtractDigitAddMul for $rayon {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <$base as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
     }
+}
+
+impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for $rayon {
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        <$base as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+        <$base as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }
+
     #[inline(always)]
     fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
         base2k: usize, lsh: usize, res_base2k: usize,
         res: &mut [i64], src: &mut [i64], carry: &mut [i64],
     ) {
-        <$base as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+        <$base as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_addmul_normalize::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
     }
 }
 $crate::rayon_forward_znx!($rayon, $base, ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));

--- a/poulpy-cpu-rayon/src/normalize.rs
+++ b/poulpy-cpu-rayon/src/normalize.rs
@@ -31,6 +31,9 @@ where
     T: Send,
     F: Fn(usize, usize, &mut [T]) + Send + Sync,
 {
+    if n == 0 {
+        return;
+    }
     let chunk = n.div_ceil(tasks).next_multiple_of(8);
     carry[..words * n]
         .par_chunks_mut(words * chunk)
@@ -183,4 +186,39 @@ pub fn ntt4x30_vec_znx_big_normalize_par<B, T>(
             )
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::for_each_range;
+
+    #[test]
+    fn test_normalization_ranges_private_scratch() {
+        rayon::ThreadPoolBuilder::new().num_threads(4).build().unwrap().install(|| {
+            for n in 0..=129 {
+                for tasks in 1..=17 {
+                    for words in [1, 3] {
+                        let visits: Vec<_> = (0..n).map(|_| AtomicUsize::new(0)).collect();
+                        let mut scratch = vec![usize::MAX; words * n + 12];
+                        let carry = &mut scratch[5..5 + words * n];
+                        let base = carry.as_ptr() as usize;
+                        for_each_range(n, tasks, words, carry, |start, len, private| {
+                            assert!(len > 0 && start + len <= n);
+                            assert_eq!(private.len(), words * len);
+                            assert_eq!(private.as_ptr() as usize - base, words * start * size_of::<usize>());
+                            for visit in &visits[start..start + len] {
+                                assert_eq!(visit.fetch_add(1, Ordering::Relaxed), 0);
+                            }
+                            private.fill(start);
+                        });
+                        assert!(visits.iter().all(|v| v.load(Ordering::Relaxed) == 1));
+                        assert!(scratch[..5].iter().chain(&scratch[5 + words * n..]).all(|&v| v == usize::MAX));
+                        assert!(scratch[5..5 + words * n].iter().all(|&v| v < n));
+                    }
+                }
+            }
+        });
+    }
 }

--- a/poulpy-cpu-rayon/src/normalize.rs
+++ b/poulpy-cpu-rayon/src/normalize.rs
@@ -6,7 +6,7 @@ use poulpy_cpu_ref::reference::{
     ntt4x30::vec_znx_big::{I128NormalizeOps, ntt4x30_vec_znx_big_normalize, ntt4x30_vec_znx_big_normalize_range_raw},
     vec_znx::{vec_znx_normalize, vec_znx_normalize_assign, vec_znx_normalize_assign_range_raw, vec_znx_normalize_range_raw},
     znx::{
-        ZnxAddAssign, ZnxCopy, ZnxExtractDigitAddMul, ZnxMulPowerOfTwoAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep,
+        I64NormalizeOps, ZnxAddAssign, ZnxCopy, ZnxMulPowerOfTwoAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep,
         ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep, ZnxNormalizeFirstStepAssign, ZnxNormalizeFirstStepCarryOnly,
         ZnxNormalizeMiddleStep, ZnxNormalizeMiddleStepAssign, ZnxNormalizeMiddleStepCarryOnly, ZnxZero,
     },
@@ -66,7 +66,7 @@ pub fn vec_znx_normalize_par<B, T>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,

--- a/poulpy-cpu-ref/Cargo.toml
+++ b/poulpy-cpu-ref/Cargo.toml
@@ -62,6 +62,7 @@ name = "max_array"
 required-features = ["enable-core"]
 
 [dev-dependencies]
+dashu-int = {workspace = true}
 poulpy-ckks = {workspace = true, features = ["test-utils"]}
 poulpy-bin-fhe = {workspace = true}
 criterion = {workspace = true}

--- a/poulpy-cpu-ref/src/fft64/znx.rs
+++ b/poulpy-cpu-ref/src/fft64/znx.rs
@@ -213,27 +213,12 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Ref {
 
 impl ZnxExtractDigitAddMul for FFT64Ref {
     #[inline(always)]
-    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        crate::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
-    }
-
-    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         znx_extract_digit_addmul_ref(base2k, lsh, res, src);
     }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i64],
-        carry: &mut [i64],
-    ) {
-        crate::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
-    }
 }
+
+impl crate::reference::normalization::I64NormalizeOps for FFT64Ref {}
 
 impl ZnxNormalizeDigit for FFT64Ref {
     #[inline(always)]
@@ -246,7 +231,7 @@ impl ZnxNormalizeDigit for FFT64Ref {
 mod normalization_tests {
     #[test]
     fn test_normalization_kernels_bounded_inputs() {
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Ref>();
-        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Ref>();
+        crate::test_suite::normalization::test_normalization_kernels::<crate::FFT64Ref>();
+        crate::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Ref>();
     }
 }

--- a/poulpy-cpu-ref/src/fft64/znx.rs
+++ b/poulpy-cpu-ref/src/fft64/znx.rs
@@ -213,8 +213,25 @@ impl ZnxNormalizeMiddleStepAssign for FFT64Ref {
 
 impl ZnxExtractDigitAddMul for FFT64Ref {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        crate::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         znx_extract_digit_addmul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        crate::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
     }
 }
 
@@ -222,5 +239,14 @@ impl ZnxNormalizeDigit for FFT64Ref {
     #[inline(always)]
     fn znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]) {
         znx_normalize_digit_ref(base2k, res, src);
+    }
+}
+
+#[cfg(test)]
+mod normalization_tests {
+    #[test]
+    fn test_normalization_kernels_bounded_inputs() {
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::FFT64Ref>();
+        poulpy_hal::test_suite::normalization::test_normalization_kernels::<crate::NTT4x30Ref>();
     }
 }

--- a/poulpy-cpu-ref/src/hal_defaults/vec_znx.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/vec_znx.rs
@@ -17,8 +17,8 @@ use crate::reference::vec_znx::{
     vec_znx_zero,
 };
 use crate::reference::znx::{
-    ZnxAdd, ZnxAddAssign, ZnxAutomorphism, ZnxAutomorphismRotate, ZnxCopy, ZnxExtractDigitAddMul, ZnxMulPowerOfTwoAssign,
-    ZnxNegate, ZnxNegateAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep, ZnxNormalizeFinalStepAssign, ZnxNormalizeFinalStepSub,
+    I64NormalizeOps, ZnxAdd, ZnxAddAssign, ZnxAutomorphism, ZnxAutomorphismRotate, ZnxCopy, ZnxMulPowerOfTwoAssign, ZnxNegate,
+    ZnxNegateAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep, ZnxNormalizeFinalStepAssign, ZnxNormalizeFinalStepSub,
     ZnxNormalizeFirstStep, ZnxNormalizeFirstStepAssign, ZnxNormalizeFirstStepCarryOnly, ZnxNormalizeMiddleStep,
     ZnxNormalizeMiddleStepAssign, ZnxNormalizeMiddleStepCarryOnly, ZnxNormalizeMiddleStepSub, ZnxRotate, ZnxSub, ZnxSubAssign,
     ZnxSubNegateAssign, ZnxSwitchRing, ZnxZero,
@@ -208,7 +208,7 @@ where
             + ZnxNormalizeMiddleStep
             + ZnxNormalizeFinalStep
             + ZnxNormalizeFirstStep
-            + ZnxExtractDigitAddMul
+            + I64NormalizeOps
             + ZnxNormalizeMiddleStepAssign
             + ZnxNormalizeFinalStepAssign
             + ZnxNormalizeDigit,
@@ -287,7 +287,7 @@ where
             + ZnxNormalizeMiddleStep
             + ZnxNormalizeFinalStep
             + ZnxNormalizeFirstStep
-            + ZnxExtractDigitAddMul
+            + I64NormalizeOps
             + ZnxNormalizeMiddleStepAssign
             + ZnxNormalizeFinalStepAssign
             + ZnxNormalizeDigit,

--- a/poulpy-cpu-ref/src/hal_defaults/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/vec_znx_big.rs
@@ -38,8 +38,8 @@ use crate::reference::{
         ntt4x30_vec_znx_big_sub_small_assign, ntt4x30_vec_znx_big_sub_small_b, ntt4x30_vec_znx_big_sub_small_negate_assign,
     },
     znx::{
-        ZnxAdd, ZnxAddAssign, ZnxAutomorphism, ZnxCopy, ZnxExtractDigitAddMul, ZnxMulPowerOfTwoAssign, ZnxNegate,
-        ZnxNegateAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep, ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep,
+        I64NormalizeOps, ZnxAdd, ZnxAddAssign, ZnxAutomorphism, ZnxCopy, ZnxMulPowerOfTwoAssign, ZnxNegate, ZnxNegateAssign,
+        ZnxNormalizeDigit, ZnxNormalizeFinalStep, ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep,
         ZnxNormalizeFirstStepCarryOnly, ZnxNormalizeMiddleStep, ZnxNormalizeMiddleStepAssign, ZnxNormalizeMiddleStepCarryOnly,
         ZnxSub, ZnxSubAssign, ZnxSubNegateAssign, ZnxZero, znx_copy_ref, znx_zero_ref,
     },
@@ -499,7 +499,7 @@ where
             + ZnxNormalizeMiddleStep
             + ZnxNormalizeFinalStep
             + ZnxNormalizeFirstStep
-            + ZnxExtractDigitAddMul
+            + I64NormalizeOps
             + ZnxNormalizeDigit
             + ZnxNormalizeMiddleStepAssign
             + ZnxNormalizeFinalStepAssign,

--- a/poulpy-cpu-ref/src/hal_defaults/vec_znx_dft.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/vec_znx_dft.rs
@@ -50,7 +50,7 @@ use crate::reference::{
         },
     },
     znx::{
-        ZnxAddAssign, ZnxCopy, ZnxExtractDigitAddMul, ZnxMulPowerOfTwoAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep,
+        I64NormalizeOps, ZnxAddAssign, ZnxCopy, ZnxMulPowerOfTwoAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep,
         ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep, ZnxNormalizeFirstStepCarryOnly, ZnxNormalizeMiddleStep,
         ZnxNormalizeMiddleStepAssign, ZnxNormalizeMiddleStepCarryOnly, ZnxZero,
     },
@@ -182,7 +182,7 @@ where
             + ZnxNormalizeMiddleStep
             + ZnxNormalizeFinalStep
             + ZnxNormalizeFirstStep
-            + ZnxExtractDigitAddMul
+            + I64NormalizeOps
             + ZnxNormalizeMiddleStepAssign
             + ZnxNormalizeFinalStepAssign
             + ZnxNormalizeDigit,

--- a/poulpy-cpu-ref/src/hal_impl/delegating_backend.rs
+++ b/poulpy-cpu-ref/src/hal_impl/delegating_backend.rs
@@ -119,31 +119,14 @@ impl ZnxExtractDigitAddMul for DelegatingFFT64Ref {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <FFT64Ref as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
     }
-
-    #[inline(always)]
-    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        <FFT64Ref as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
-    }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i64],
-        carry: &mut [i64],
-    ) {
-        <FFT64Ref as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
-            base2k, lsh, res_base2k, res, src, carry,
-        );
-    }
 }
+
+impl crate::reference::normalization::I64NormalizeOps for DelegatingFFT64Ref {}
 impl_forward_znx_trait!(ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
 
 #[test]
 fn test_normalization_kernels_delegating_fft64_ref() {
-    poulpy_hal::test_suite::normalization::test_normalization_kernels::<DelegatingFFT64Ref>();
+    crate::test_suite::normalization::test_normalization_kernels::<DelegatingFFT64Ref>();
 }
 
 impl ReimFFTExecute<ReimFFTTable<f64>, f64> for DelegatingFFT64Ref {

--- a/poulpy-cpu-ref/src/hal_impl/delegating_backend.rs
+++ b/poulpy-cpu-ref/src/hal_impl/delegating_backend.rs
@@ -114,11 +114,37 @@ impl_forward_znx_trait!(
     ZnxNormalizeFinalStepAssign,
     znx_normalize_final_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64])
 );
-impl_forward_znx_trait!(
-    ZnxExtractDigitAddMul,
-    znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64])
-);
+impl ZnxExtractDigitAddMul for DelegatingFFT64Ref {
+    #[inline(always)]
+    fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <FFT64Ref as ZnxExtractDigitAddMul>::znx_extract_digit_addmul(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        <FFT64Ref as ZnxExtractDigitAddMul>::znx_extract_digit_mul(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <FFT64Ref as ZnxExtractDigitAddMul>::znx_extract_digit_addmul_normalize::<OVERWRITE>(
+            base2k, lsh, res_base2k, res, src, carry,
+        );
+    }
+}
 impl_forward_znx_trait!(ZnxNormalizeDigit, znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]));
+
+#[test]
+fn test_normalization_kernels_delegating_fft64_ref() {
+    poulpy_hal::test_suite::normalization::test_normalization_kernels::<DelegatingFFT64Ref>();
+}
 
 impl ReimFFTExecute<ReimFFTTable<f64>, f64> for DelegatingFFT64Ref {
     #[inline(always)]

--- a/poulpy-cpu-ref/src/lib.rs
+++ b/poulpy-cpu-ref/src/lib.rs
@@ -47,6 +47,7 @@ pub mod ntt4x30;
 pub mod capabilities;
 pub mod reference;
 pub mod table_cache;
+pub mod test_suite;
 
 #[cfg(test)]
 mod tests;

--- a/poulpy-cpu-ref/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/ntt4x30/vec_znx_big.rs
@@ -8,3 +8,7 @@ use crate::reference::ntt4x30::{I128BigOps, I128NormalizeOps};
 
 impl I128BigOps for NTT4x30Ref {}
 impl I128NormalizeOps for NTT4x30Ref {}
+
+impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Ref {
+    const FUSE_NORMALIZE: bool = false;
+}

--- a/poulpy-cpu-ref/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/ntt4x30/vec_znx_big.rs
@@ -1,14 +1,12 @@
 //! Large-coefficient (i128) ring element vector support for [`NTT4x30Ref`](crate::NTT4x30Ref).
 //!
-//! The shared `poulpy-hal` NTT4x30 defaults rely on backend-provided `I128BigOps`
+//! The shared `poulpy-cpu-ref` NTT4x30 defaults rely on backend-provided `I128BigOps`
 //! and `I128NormalizeOps` hooks for vectorized i128 operations.
 
 use crate::NTT4x30Ref;
 use crate::reference::ntt4x30::{I128BigOps, I128NormalizeOps};
 
 impl I128BigOps for NTT4x30Ref {}
-impl I128NormalizeOps for NTT4x30Ref {}
-
-impl poulpy_hal::reference::znx::ZnxExtractDigitAddMulI128 for NTT4x30Ref {
+impl I128NormalizeOps for NTT4x30Ref {
     const FUSE_NORMALIZE: bool = false;
 }

--- a/poulpy-cpu-ref/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-ref/src/ntt4x30/znx.rs
@@ -205,27 +205,12 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Ref {
 
 impl ZnxExtractDigitAddMul for NTT4x30Ref {
     #[inline(always)]
-    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        crate::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
-    }
-
-    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         znx_extract_digit_addmul_ref(base2k, lsh, res, src);
     }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i64],
-        carry: &mut [i64],
-    ) {
-        crate::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
-    }
 }
+
+impl crate::reference::normalization::I64NormalizeOps for NTT4x30Ref {}
 
 impl ZnxNormalizeDigit for NTT4x30Ref {
     #[inline(always)]

--- a/poulpy-cpu-ref/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-ref/src/ntt4x30/znx.rs
@@ -205,8 +205,25 @@ impl ZnxNormalizeMiddleStepAssign for NTT4x30Ref {
 
 impl ZnxExtractDigitAddMul for NTT4x30Ref {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        crate::reference::znx::znx_extract_digit_mul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         znx_extract_digit_addmul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        crate::reference::znx::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
     }
 }
 

--- a/poulpy-cpu-ref/src/reference/fft64/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/reference/fft64/vec_znx_big.rs
@@ -18,8 +18,8 @@ use crate::{
             vec_znx_sub_negate_assign,
         },
         znx::{
-            ZnxAdd, ZnxAddAssign, ZnxAutomorphism, ZnxCopy, ZnxExtractDigitAddMul, ZnxMulPowerOfTwoAssign, ZnxNegate,
-            ZnxNegateAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep, ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep,
+            I64NormalizeOps, ZnxAdd, ZnxAddAssign, ZnxAutomorphism, ZnxCopy, ZnxMulPowerOfTwoAssign, ZnxNegate, ZnxNegateAssign,
+            ZnxNormalizeDigit, ZnxNormalizeFinalStep, ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep,
             ZnxNormalizeFirstStepCarryOnly, ZnxNormalizeMiddleStep, ZnxNormalizeMiddleStepAssign,
             ZnxNormalizeMiddleStepCarryOnly, ZnxSub, ZnxSubAssign, ZnxSubNegateAssign, ZnxZero, znx_add_normal_f64_ref,
         },
@@ -176,7 +176,7 @@ pub fn vec_znx_big_normalize<R, A, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeDigit
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign,

--- a/poulpy-cpu-ref/src/reference/mod.rs
+++ b/poulpy-cpu-ref/src/reference/mod.rs
@@ -6,6 +6,7 @@
 //! [`poulpy_hal::test_suite`] module.
 
 pub mod fft64;
+pub mod normalization;
 pub mod ntt4x30;
 pub mod vec_znx;
 pub mod vmp_select;
@@ -27,7 +28,8 @@ impl<T> SendPtr<T> {
 unsafe impl<T> Send for SendPtr<T> {}
 unsafe impl<T> Sync for SendPtr<T> {}
 
-/// Re-exported from [`poulpy_hal::reference::znx`], where the portable scalar
-/// kernels now live so that every crate can reach them without depending on a
-/// backend.
-pub use poulpy_hal::reference::znx;
+/// Portable HAL primitives and CPU-specific normalization kernels.
+pub mod znx {
+    pub use super::normalization::*;
+    pub use poulpy_hal::reference::znx::*;
+}

--- a/poulpy-cpu-ref/src/reference/normalization.rs
+++ b/poulpy-cpu-ref/src/reference/normalization.rs
@@ -1,0 +1,99 @@
+//! CPU normalization kernels and optimization hooks shared by CPU backends.
+
+use poulpy_hal::reference::znx::{ZnxExtractDigitAddMul, get_carry_i64, get_carry_i128, get_digit_i64, get_digit_i128};
+
+/// CPU extraction hooks used by the shared normalization loops.
+/// Implementations may override the scalar defaults to reduce memory passes.
+/// Source and carry lengths must cover `res`; shorter slices panic before writing.
+/// Arithmetic bounds are those of the HAL extraction and normalization primitives.
+pub trait I64NormalizeOps: ZnxExtractDigitAddMul {
+    #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        znx_extract_digit_mul_ref(base2k, lsh, res, src);
+    }
+
+    /// Requires `1 <= res_base2k <= 62` and representable accumulated sums
+    /// and centered subtractions in i64.
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+    }
+}
+
+#[inline(always)]
+pub fn znx_extract_digit_addmul_impl_ref<const OVERWRITE: bool>(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    assert!(src.len() >= res.len());
+    for (r, s) in res.iter_mut().zip(src.iter_mut()) {
+        let digit: i64 = get_digit_i64(base2k, *s);
+        *s = get_carry_i64(base2k, *s, digit);
+        *r = if OVERWRITE { digit << lsh } else { *r + (digit << lsh) };
+    }
+}
+
+#[inline(always)]
+pub fn znx_extract_digit_mul_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    znx_extract_digit_addmul_impl_ref::<true>(base2k, lsh, res, src);
+}
+
+#[inline(always)]
+pub fn znx_extract_digit_addmul_normalize_ref<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i64],
+    carry: &mut [i64],
+) {
+    assert!(src.len() >= res.len());
+    assert!(carry.len() >= res.len());
+    for ((r, s), c) in res.iter_mut().zip(src.iter_mut()).zip(carry.iter_mut()) {
+        let digit = get_digit_i64(base2k, *s);
+        *s = get_carry_i64(base2k, *s, digit);
+        let partial = if OVERWRITE { digit << lsh } else { *r + (digit << lsh) };
+        let sum = partial + *c;
+        *r = get_digit_i64(res_base2k, sum);
+        *c = get_carry_i64(res_base2k, sum, *r);
+    }
+}
+
+/// Fused wide extraction and destination carry normalization.
+pub fn znx_extract_digit_addmul_normalize_i128_ref<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i128],
+    carry: &mut [i128],
+) {
+    assert!(src.len() >= res.len());
+    assert!(carry.len() >= res.len());
+    for ((r, s), c) in res.iter_mut().zip(src).zip(carry) {
+        let digit = get_digit_i128(base2k, *s);
+        *s = get_carry_i128(base2k, *s, digit);
+        let previous = if OVERWRITE { 0i64 } else { *r };
+        let accum = previous.wrapping_add((digit as i64).wrapping_shl(lsh as u32)) as i128;
+        let d = get_digit_i128(res_base2k, accum);
+        let q = get_carry_i128(res_base2k, accum, d);
+        let sum = d + *c;
+        let out = get_digit_i128(res_base2k, sum);
+        *r = out as i64;
+        *c = q + get_carry_i128(res_base2k, sum, out);
+    }
+}
+
+/// Extract a wide source digit and initialize a destination limb.
+pub fn znx_extract_digit_mul_i128_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+    assert!(src.len() >= res.len());
+    for (r, s) in res.iter_mut().zip(src) {
+        let digit = get_digit_i128(base2k, *s);
+        *s = get_carry_i128(base2k, *s, digit);
+        *r = (digit as i64).wrapping_shl(lsh as u32);
+    }
+}

--- a/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
@@ -60,15 +60,6 @@ fn nfc_add_assign(res: &mut [i128], a: &[i128]) {
     res.iter_mut().zip(a.iter()).for_each(|(r, &ai)| *r = r.wrapping_add(ai));
 }
 
-#[inline(always)]
-fn nfc_acc_assign<O: AssignOp>(res: &mut [i128], a: &[i128]) {
-    if O::SUB {
-        res.iter_mut().zip(a.iter()).for_each(|(r, &ai)| *r = r.wrapping_sub(ai));
-    } else {
-        nfc_add_assign(res, a);
-    }
-}
-
 /// Multiply an `i128` slice by `2^power` in-place (positive = left shift, negative = right shift).
 #[inline(always)]
 fn nfc_mul_pow2_assign(power: i64, x: &mut [i128]) {
@@ -79,7 +70,7 @@ fn nfc_mul_pow2_assign(power: i64, x: &mut [i128]) {
     }
 }
 
-/// First carry-only step from the MSB `i128` limb of `a` (no prior carry).
+/// First carry-only step from the least significant `i128` limb of `a` (no prior carry).
 ///
 /// Analogous to `znx_normalize_first_step_carry_only_ref` but for `i128`.
 #[inline(always)]
@@ -221,16 +212,6 @@ fn nfc_middle_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64],
     }
 }
 
-#[inline(always)]
-fn nfc_middle_carry_assign<O: AssignOp>(base2k: usize, res: &mut [i64], carry: &mut [i128]) {
-    debug_assert!(res.len() <= carry.len());
-    res.iter_mut().zip(carry.iter_mut()).for_each(|(r, c)| {
-        let out = get_digit_i128(base2k, *c);
-        *r = O::apply_i64(*r, out as i64);
-        *c = get_carry_i128(base2k, *c, out);
-    });
-}
-
 /// Middle in-place: update an existing `i64` `res` limb using `i128` carry.
 ///
 /// Analogous to `znx_normalize_middle_step_assign_ref` but with `i128` carry.
@@ -306,14 +287,6 @@ fn nfc_final_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], 
     }
 }
 
-#[inline(always)]
-fn nfc_final_carry_assign<O: AssignOp>(base2k: usize, res: &mut [i64], carry: &mut [i128]) {
-    debug_assert!(res.len() <= carry.len());
-    res.iter_mut().zip(carry.iter_mut()).for_each(|(r, c)| {
-        *r = O::apply_i64(*r, get_digit_i128(base2k, *c) as i64);
-    });
-}
-
 /// Normalize an `i128` limb into an `i128` intermediate (`a_norm`), with `i128` carry.
 ///
 /// Used in the cross-base2k path to convert the `a` limb to the standard representation
@@ -356,15 +329,6 @@ fn nfc_extract_digit_addmul(base2k: usize, scale: usize, res: &mut [i64], src: &
         let digit = get_digit_i128(base2k, *s);
         *s = get_carry_i128(base2k, *s, digit);
         *r = r.wrapping_add((digit as i64).wrapping_shl(scale as u32));
-    }
-}
-
-#[inline(always)]
-fn nfc_extract_digit_assignmul<O: AssignOp>(base2k: usize, scale: usize, res: &mut [i64], src: &mut [i128]) {
-    for (r, s) in res.iter_mut().zip(src.iter_mut()) {
-        let digit = get_digit_i128(base2k, *s);
-        *s = get_carry_i128(base2k, *s, digit);
-        *r = O::apply_i64(*r, (digit as i64).wrapping_shl(scale as u32));
     }
 }
 
@@ -447,90 +411,8 @@ fn ntt4x30_vec_znx_big_normalize_inter<A, BE>(
         );
     }
 
-    // Propagate carry to remaining lower res limbs (which were zeroed above).
-    for j in 0..res_end {
-        res.at_mut(res_end - j - 1).fill(0);
-        if j == res_end - 1 {
-            BE::nfc_final_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
-        } else {
-            BE::nfc_middle_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn ntt4x30_vec_znx_big_normalize_inter_assign<O, R, A, BE>(
-    base2k: usize,
-    res: &mut R,
-    res_offset: i64,
-    res_col: usize,
-    a: &A,
-    a_col: usize,
-    carry: &mut [i128],
-) where
-    O: AssignOp,
-    R: VecZnxToBackendMut<BE>,
-    A: VecZnxBigToBackendRef<BE>,
-    BE: Backend<BigWord = i128, ZnxWord = i64> + I128NormalizeOps,
-    for<'x> BE::BufMut<'x>: HostDataMut,
-    for<'x> BE::BufRef<'x>: HostDataRef,
-{
-    let mut res = res.to_backend_mut();
-    let a = a.to_backend_ref();
-
-    let n = res.n();
-    let res_size = res.size();
-    let a_size = a.size();
-
-    let (carry, _) = carry.split_at_mut(n);
-
-    let mut lsh: i64 = res_offset % base2k as i64;
-    let mut limbs_offset: i64 = res_offset / base2k as i64;
-
-    if res_offset < 0 && lsh != 0 {
-        lsh = (lsh + base2k as i64) % (base2k as i64);
-        limbs_offset -= 1;
-    }
-
-    let lsh_pos: usize = lsh as usize;
-
-    let res_end: usize = (-limbs_offset).clamp(0, res_size as i64) as usize;
-    let res_start: usize = (a_size as i64 - limbs_offset).clamp(0, res_size as i64) as usize;
-    let a_end: usize = limbs_offset.clamp(0, a_size as i64) as usize;
-    let a_start: usize = (res_size as i64 + limbs_offset).clamp(0, a_size as i64) as usize;
-
-    let a_out_range: usize = a_size.saturating_sub(a_start);
-
-    for j in 0..a_out_range {
-        if j == 0 {
-            nfc_first_carry_only(base2k, lsh_pos, a.at(a_col, a_size - j - 1), carry);
-        } else {
-            nfc_middle_carry_only(base2k, lsh_pos, a.at(a_col, a_size - j - 1), carry);
-        }
-    }
-
-    if a_out_range == 0 {
-        nfc_zero(carry);
-    }
-
-    let mid_range: usize = a_start.saturating_sub(a_end);
-
-    for j in 0..mid_range {
-        BE::nfc_middle_step_into::<O>(
-            base2k,
-            lsh_pos,
-            res.at_mut(res_col, res_start - j - 1),
-            a.at(a_col, a_start - j - 1),
-            carry,
-        );
-    }
-
-    for j in 0..res_end {
-        if j == res_end - 1 {
-            nfc_final_carry_assign::<O>(base2k, res.at_mut(res_col, res_end - j - 1), carry);
-        } else {
-            nfc_middle_carry_assign::<O>(base2k, res.at_mut(res_col, res_end - j - 1), carry);
-        }
+    for j in (0..res_end).rev() {
+        BE::znx_extract_digit_mul_i128(base2k, 0, res.at_mut(j), carry);
     }
 }
 
@@ -588,8 +470,7 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
     let a_end: usize = a_end_bit / a_base2k;
     let a_start: usize = a_start_bit.div_ceil(a_base2k);
 
-    // Zero all res limbs.
-    for j in 0..res_size {
+    for j in res_start..res_size {
         res.at_mut(j).fill(0);
     }
 
@@ -612,6 +493,7 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
 
     let mut res_acc_left: usize = res_base2k;
     let mut res_limb: usize = res_start - 1;
+    let mut initialized = false;
 
     let mid_range: usize = a_start.saturating_sub(a_end);
 
@@ -638,9 +520,25 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
             let res_slice = res.at_mut(res_limb);
             let a_take: usize = a_base2k.min(a_take_left).min(res_acc_left);
 
+            let flushed = BE::FUSE_NORMALIZE && a_take != 0 && a_take == res_acc_left;
             if a_take != 0 {
                 let scale: usize = res_base2k - res_acc_left;
-                nfc_extract_digit_addmul(a_take, scale, res_slice, a_norm);
+                if flushed {
+                    if initialized {
+                        BE::znx_extract_digit_addmul_normalize_i128::<false>(
+                            a_take, scale, res_base2k, res_slice, a_norm, res_carry,
+                        );
+                    } else {
+                        BE::znx_extract_digit_addmul_normalize_i128::<true>(
+                            a_take, scale, res_base2k, res_slice, a_norm, res_carry,
+                        );
+                    }
+                } else if initialized {
+                    nfc_extract_digit_addmul(a_take, scale, res_slice, a_norm);
+                } else {
+                    BE::znx_extract_digit_mul_i128(a_take, scale, res_slice, a_norm);
+                }
+                initialized = true;
                 a_take_left -= a_take;
                 res_acc_left -= a_take;
             }
@@ -652,149 +550,15 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
                         let scale: usize = res_base2k - res_acc_left;
                         nfc_extract_digit_addmul(res_acc_left, scale, res_slice, a_carry);
                     }
-                    BE::nfc_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                    if !flushed {
+                        BE::nfc_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                    }
                     nfc_add_assign(res_carry, a_carry);
                     break 'outer;
                 }
 
-                if res_limb == 0 {
-                    break 'outer;
-                }
-
-                res_acc_left += res_base2k;
-                res_limb -= 1;
-            }
-
-            if a_take_left == 0 {
-                nfc_add_assign(a_carry, a_norm);
-                break 'inner;
-            }
-        }
-    }
-
-    // Propagate carry into the lower (already-zero) res limbs.
-    if res_end != 0 {
-        let carry_to_use = if a_start == a_end { a_carry } else { res_carry };
-        for j in 0..res_end {
-            if j == res_end - 1 {
-                BE::nfc_final_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
-            } else {
-                BE::nfc_middle_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
-            }
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn ntt4x30_vec_znx_big_normalize_cross_assign<O, R, A, BE>(
-    res: &mut R,
-    res_base2k: usize,
-    res_offset: i64,
-    res_col: usize,
-    a: &A,
-    a_base2k: usize,
-    a_col: usize,
-    carry: &mut [i128],
-) where
-    O: AssignOp,
-    R: VecZnxToBackendMut<BE>,
-    A: VecZnxBigToBackendRef<BE>,
-    BE: Backend<BigWord = i128, ZnxWord = i64> + I128NormalizeOps,
-    for<'x> BE::BufMut<'x>: HostDataMut,
-    for<'x> BE::BufRef<'x>: HostDataRef,
-{
-    let mut res = res.to_backend_mut();
-    let a = a.to_backend_ref();
-
-    let n = res.n();
-    let res_size = res.size();
-    let a_size = a.size();
-
-    let (a_norm, carry) = carry.split_at_mut(n);
-    let (res_carry, a_carry) = carry[..2 * n].split_at_mut(n);
-    nfc_zero(res_carry);
-
-    let a_tot_bits: usize = a_size * a_base2k;
-    let res_tot_bits: usize = res_size * res_base2k;
-
-    let mut lsh: i64 = res_offset % a_base2k as i64;
-    let mut limbs_offset: i64 = res_offset / a_base2k as i64;
-
-    if res_offset < 0 && lsh != 0 {
-        lsh = (lsh + a_base2k as i64) % (a_base2k as i64);
-        limbs_offset -= 1;
-    }
-
-    let lsh_pos: usize = lsh as usize;
-
-    let res_end_bit: usize = (-limbs_offset * a_base2k as i64).clamp(0, res_tot_bits as i64) as usize;
-    let res_start_bit: usize = (a_tot_bits as i64 - limbs_offset * a_base2k as i64).clamp(0, res_tot_bits as i64) as usize;
-    let a_end_bit: usize = (limbs_offset * a_base2k as i64).clamp(0, a_tot_bits as i64) as usize;
-    let a_start_bit: usize = (res_tot_bits as i64 + limbs_offset * a_base2k as i64).clamp(0, a_tot_bits as i64) as usize;
-
-    let res_end: usize = res_end_bit / res_base2k;
-    let res_start: usize = res_start_bit.div_ceil(res_base2k);
-    let a_end: usize = a_end_bit / a_base2k;
-    let a_start: usize = a_start_bit.div_ceil(a_base2k);
-
-    if res_start == 0 {
-        return;
-    }
-
-    let a_out_range: usize = a_size.saturating_sub(a_start);
-    for j in 0..a_out_range {
-        if j == 0 {
-            nfc_first_carry_only(a_base2k, lsh_pos, a.at(a_col, a_size - j - 1), a_carry);
-        } else {
-            nfc_middle_carry_only(a_base2k, lsh_pos, a.at(a_col, a_size - j - 1), a_carry);
-        }
-    }
-    if a_out_range == 0 {
-        nfc_zero(a_carry);
-    }
-
-    let mut res_acc_left: usize = res_base2k;
-    let mut res_limb: usize = res_start - 1;
-    let mid_range: usize = a_start.saturating_sub(a_end);
-
-    'outer: for j in 0..mid_range {
-        let a_limb: usize = a_start - j - 1;
-        let a_slice: &[i128] = a.at(a_col, a_limb);
-
-        let mut a_take_left: usize = a_base2k;
-        nfc_middle_step_i128(a_base2k, lsh_pos, a_norm, a_slice, a_carry);
-
-        if j == 0 {
-            if !(a_tot_bits - a_start_bit).is_multiple_of(a_base2k) {
-                let take: usize = (a_tot_bits - a_start_bit) % a_base2k;
-                nfc_mul_pow2_assign(-(take as i64), a_norm);
-                a_take_left -= take;
-            } else if !(res_tot_bits - res_start_bit).is_multiple_of(res_base2k) {
-                res_acc_left -= (res_tot_bits - res_start_bit) % res_base2k;
-            }
-        }
-
-        'inner: loop {
-            let res_slice: &mut [i64] = res.at_mut(res_col, res_limb);
-            let a_take: usize = a_base2k.min(a_take_left).min(res_acc_left);
-
-            if a_take != 0 {
-                let scale: usize = res_base2k - res_acc_left;
-                nfc_extract_digit_assignmul::<O>(a_take, scale, res_slice, a_norm);
-                a_take_left -= a_take;
-                res_acc_left -= a_take;
-            }
-
-            if res_acc_left == 0 || a_limb == 0 {
-                if a_limb == 0 && a_take_left == 0 {
-                    nfc_add_assign(a_carry, a_norm);
-                    if res_acc_left != 0 {
-                        let scale: usize = res_base2k - res_acc_left;
-                        nfc_extract_digit_assignmul::<O>(res_acc_left, scale, res_slice, a_carry);
-                    }
+                if !flushed {
                     BE::nfc_middle_step_assign(res_base2k, 0, res_slice, res_carry);
-                    nfc_acc_assign::<O>(res_carry, a_carry);
-                    break 'outer;
                 }
 
                 if res_limb == 0 {
@@ -803,6 +567,7 @@ fn ntt4x30_vec_znx_big_normalize_cross_assign<O, R, A, BE>(
 
                 res_acc_left += res_base2k;
                 res_limb -= 1;
+                initialized = false;
             }
 
             if a_take_left == 0 {
@@ -812,14 +577,11 @@ fn ntt4x30_vec_znx_big_normalize_cross_assign<O, R, A, BE>(
         }
     }
 
+    // Write the remaining more significant digits.
     if res_end != 0 {
         let carry_to_use = if a_start == a_end { a_carry } else { res_carry };
-        for j in 0..res_end {
-            if j == res_end - 1 {
-                nfc_final_carry_assign::<O>(res_base2k, res.at_mut(res_col, res_end - j - 1), carry_to_use);
-            } else {
-                nfc_middle_carry_assign::<O>(res_base2k, res.at_mut(res_col, res_end - j - 1), carry_to_use);
-            }
+        for j in (0..res_end).rev() {
+            BE::znx_extract_digit_mul_i128(res_base2k, 0, res.at_mut(j), carry_to_use);
         }
     }
 }
@@ -956,7 +718,10 @@ pub trait I128BigOps {
 /// loop logic.  All methods have scalar default implementations.
 ///
 /// This is the normalization-specific counterpart of [`I128BigOps`].
-pub trait I128NormalizeOps {
+/// Input limbs and incoming carries must have magnitude at most `2^126`;
+/// shifted digits and destination sums must be representable. These bounds
+/// include the centered NTT4x30 IDFT output, whose magnitude is below `2^119`.
+pub trait I128NormalizeOps: crate::reference::znx::ZnxExtractDigitAddMulI128 {
     /// Convert `i128` input + carry into `i64` output, updating carry in place.
     ///
     /// Equivalent to the private `nfc_middle_step` helper.
@@ -1430,6 +1195,8 @@ where
 ///
 /// Extracts `res.size()` signed base-2^`res_base2k` digits from the extended-precision
 /// accumulator in `a`, applying a bit-level `res_offset` shift before decomposition.
+/// Source coefficients must have magnitude at most `2^126`, including after additions.
+/// The centered NTT4x30 IDFT output satisfies the stronger bound `|a| < 2^119`.
 ///
 /// `carry` must have at least `ntt4x30_vec_znx_big_normalize_tmp_bytes(n) / size_of::<i128>()`
 /// elements (i.e., `3 * n` `i128` values).
@@ -1505,8 +1272,16 @@ fn ntt4x30_vec_znx_big_normalize_range<R, A, BE>(
 ///
 /// # Safety
 ///
-/// `res_ptr` must address a valid `n * cols * size` allocation. Any live calls
-/// using the same allocation must write disjoint coefficient ranges.
+/// `res_ptr` must be non-null, aligned for `i64`, and address at least
+/// `n * cols * size` initialized `i64` values; layout arithmetic must not overflow.
+/// The source must have valid initialized storage, degree `n`, and column `a_col`.
+/// Require `res_col < cols`, `coeff_start <= n`, `coeff_len <= n - coeff_start`,
+/// and at least `3 * coeff_len` private scratch words in `carry`.
+///
+/// For every destination limb, the selected coefficient range must be exclusively
+/// writable for this call and must not overlap source or scratch storage. Concurrent
+/// calls may share the destination allocation only with disjoint coefficient ranges.
+/// Source reads must remain immutable, and scratch must not overlap the source.
 #[allow(clippy::too_many_arguments)]
 #[doc(hidden)]
 pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
@@ -1536,6 +1311,24 @@ pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
         assert!(carry.len() >= 3 * coeff_len);
     }
     let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
+    let input = a.to_backend_ref();
+    let a_bits = (input.size() * a_base2k) as i64;
+    let res_bits = (size * res_base2k) as i64;
+    if input.size() == 0 || a_base2k > 63 || res_base2k > 63 || res_offset < a_bits - res_bits || res_offset >= a_bits {
+        for i in 0..coeff_len {
+            crate::reference::vec_znx::normalize_exact::<false, _, _>(
+                |j| input.at(a_col, j)[coeff_start + i],
+                input.size(),
+                a_base2k,
+                size,
+                res_base2k,
+                res_offset,
+                |j, digit| res.at_mut(j)[i] = digit,
+            );
+        }
+        return;
+    }
+
     if res_base2k == a_base2k {
         ntt4x30_vec_znx_big_normalize_inter(
             res_base2k,
@@ -1564,6 +1357,8 @@ pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
     }
 }
 
+/// Adds or subtracts normalized `a` under the source bounds of
+/// [`ntt4x30_vec_znx_big_normalize`].
 #[allow(clippy::too_many_arguments)]
 pub fn ntt4x30_vec_znx_big_normalize_assign<O, R, A, BE>(
     res: &mut R,
@@ -1582,13 +1377,31 @@ pub fn ntt4x30_vec_znx_big_normalize_assign<O, R, A, BE>(
     for<'x> BE::BufMut<'x>: HostDataMut,
     for<'x> BE::BufRef<'x>: HostDataRef,
 {
-    if res_base2k == a_base2k {
-        ntt4x30_vec_znx_big_normalize_inter_assign::<O, _, _, _>(res_base2k, res, res_offset, res_col, a, a_col, carry);
-    } else {
-        ntt4x30_vec_znx_big_normalize_cross_assign::<O, _, _, _>(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, carry);
+    let input = a.to_backend_ref();
+    let mut output = res.to_backend_mut();
+    let output_size = output.size();
+    debug_assert!(carry.len() >= 3 * output.n());
+    for i in 0..output.n() {
+        let mut extra = 0i128;
+        crate::reference::vec_znx::normalize_exact::<false, _, _>(
+            |j| input.at(a_col, j)[i],
+            input.size(),
+            a_base2k,
+            output_size,
+            res_base2k,
+            res_offset,
+            |j, digit| {
+                let value = &mut output.at_mut(res_col, j)[i];
+                let signed = if O::SUB { -(digit as i128) } else { digit as i128 };
+                let total = *value as i128 + signed + extra;
+                *value = total as i64;
+                extra = (total - *value as i128) >> res_base2k;
+            },
+        );
     }
 }
 
+/// Adds normalized `a` under the source bounds of [`ntt4x30_vec_znx_big_normalize`].
 #[allow(clippy::too_many_arguments)]
 pub fn ntt4x30_vec_znx_big_normalize_add_assign<R, A, BE>(
     res: &mut R,
@@ -1609,6 +1422,7 @@ pub fn ntt4x30_vec_znx_big_normalize_add_assign<R, A, BE>(
     ntt4x30_vec_znx_big_normalize_assign::<AddOp, _, _, _>(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, carry);
 }
 
+/// Subtracts normalized `a` under the source bounds of [`ntt4x30_vec_znx_big_normalize`].
 #[allow(clippy::too_many_arguments)]
 pub fn ntt4x30_vec_znx_big_normalize_sub_assign<R, A, BE>(
     res: &mut R,

--- a/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
@@ -39,7 +39,7 @@ use crate::{
     },
     reference::{
         vec_znx::VecZnxRangeMut,
-        znx::{get_carry_i128, get_digit_i128},
+        znx::{get_carry_i128, get_digit_i128, znx_extract_digit_addmul_normalize_i128_ref, znx_extract_digit_mul_i128_ref},
     },
     source::Source,
 };
@@ -713,7 +713,7 @@ pub trait I128BigOps {
 
 /// Per-slice `i128→i64` normalization kernels, dispatched via the backend type parameter.
 ///
-/// The three hot-path helpers used inside [`ntt4x30_vec_znx_big_normalize`] are expressed
+/// The hot-path helpers used inside [`ntt4x30_vec_znx_big_normalize`] are expressed
 /// as trait methods so that SIMD backends can override them without duplicating the outer
 /// loop logic.  All methods have scalar default implementations.
 ///
@@ -721,7 +721,28 @@ pub trait I128BigOps {
 /// Input limbs and incoming carries must have magnitude at most `2^126`;
 /// shifted digits and destination sums must be representable. These bounds
 /// include the centered NTT4x30 IDFT output, whose magnitude is below `2^119`.
-pub trait I128NormalizeOps: crate::reference::znx::ZnxExtractDigitAddMulI128 {
+pub trait I128NormalizeOps {
+    /// Selects the fused flush in the shared CPU loop.
+    const FUSE_NORMALIZE: bool = true;
+
+    /// Requires `1 <= base2k`, `base2k + lsh <= 63` and `src.len() >= res.len()`.
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+    }
+
+    /// Also requires `1 <= res_base2k <= 63` and a representable i64 destination sum.
+    /// Short source or carry slices panic before writing; unused tails are unchanged.
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+    }
+
     /// Convert `i128` input + carry into `i64` output, updating carry in place.
     ///
     /// Equivalent to the private `nfc_middle_step` helper.

--- a/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
@@ -1312,9 +1312,7 @@ pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
     }
     let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
     let input = a.to_backend_ref();
-    let a_bits = (input.size() * a_base2k) as i64;
-    let res_bits = (size * res_base2k) as i64;
-    if input.size() == 0 || a_base2k > 63 || res_base2k > 63 || res_offset < a_bits - res_bits || res_offset >= a_bits {
+    if crate::reference::vec_znx::normalize_needs_exact(input.size(), a_base2k, size, res_base2k, res_offset) {
         for i in 0..coeff_len {
             crate::reference::vec_znx::normalize_exact::<false, _, _>(
                 |j| input.at(a_col, j)[coeff_start + i],

--- a/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
+++ b/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
@@ -7,7 +7,7 @@ use std::{marker::PhantomData, mem::size_of};
 use crate::{
     layouts::{Backend, HostDataMut, HostDataRef, VecZnxBackendMut, VecZnxBackendRef, ZnxView, ZnxViewMut},
     reference::znx::{
-        ZnxAddAssign, ZnxCopy, ZnxExtractDigitAddMul, ZnxMulPowerOfTwoAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep,
+        I64NormalizeOps, ZnxAddAssign, ZnxCopy, ZnxMulPowerOfTwoAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep,
         ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep, ZnxNormalizeFirstStepAssign, ZnxNormalizeFirstStepCarryOnly,
         ZnxNormalizeMiddleStep, ZnxNormalizeMiddleStepAssign, ZnxNormalizeMiddleStepCarryOnly, ZnxZero,
     },
@@ -96,7 +96,7 @@ pub fn vec_znx_normalize_coeff<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,
@@ -175,7 +175,7 @@ fn vec_znx_normalize_coeff_inter_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeMiddleStepAssign
-        + ZnxExtractDigitAddMul,
+        + I64NormalizeOps,
     BE::BufMut<'r>: HostDataMut,
     BE::BufRef<'a>: HostDataRef,
 {
@@ -259,7 +259,7 @@ fn vec_znx_normalize_coeff_cross_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,
@@ -435,7 +435,7 @@ pub fn vec_znx_normalize<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,
@@ -488,7 +488,7 @@ fn vec_znx_normalize_range<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,
@@ -563,7 +563,7 @@ pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,
@@ -637,7 +637,7 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeMiddleStepAssign
-        + ZnxExtractDigitAddMul,
+        + I64NormalizeOps,
     BE::BufRef<'a>: HostDataRef,
 {
     let (lo, hi) = (coeff_start, coeff_start + coeff_len);
@@ -726,7 +726,7 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStep
         + ZnxNormalizeFirstStep
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,

--- a/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
+++ b/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
@@ -1,3 +1,7 @@
+//! Shared normalization loops. Public inputs follow [`crate::api::VecZnxNormalize`]:
+//! i64 coefficients in `[-2^62, 2^62]` and radix widths in `1..=62`.
+//! Coefficient, in-place and disjoint-range entrypoints share these bounds.
+
 use std::{marker::PhantomData, mem::size_of};
 
 use crate::{
@@ -83,6 +87,20 @@ pub fn vec_znx_normalize_coeff<'r, 'a, BE>(
     BE::BufMut<'r>: HostDataMut,
     BE::BufRef<'a>: HostDataRef,
 {
+    let a_bits = (a.size() * a_base2k) as i64;
+    let res_bits = (res.size() * res_base2k) as i64;
+    if a.size() == 0 || a_base2k > 63 || res_base2k > 63 || res_offset < a_bits - res_bits || res_offset >= a_bits {
+        normalize_exact::<true, _, _>(
+            |j| a.at(a_col, j)[a_coeff] as i128,
+            a.size(),
+            a_base2k,
+            res.size(),
+            res_base2k,
+            res_offset,
+            |j, digit| res.at_mut(res_col, j)[0] = digit,
+        );
+        return;
+    }
     match res_base2k == a_base2k {
         true => vec_znx_normalize_coeff_inter_base2k::<BE>(res_base2k, res, res_offset, res_col, a, a_col, a_coeff, carry),
         false => {
@@ -109,6 +127,10 @@ pub fn vec_znx_normalize_coeff_assign<'r, BE>(
 
     let res_size: usize = res.size();
     let carry = &mut carry[..1];
+
+    if base2k == 64 {
+        return;
+    }
 
     for j in (0..res_size).rev() {
         let dst = &mut res.at_mut(res_col, j)[res_coeff..res_coeff + 1];
@@ -138,7 +160,8 @@ fn vec_znx_normalize_coeff_inter_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStepCarryOnly
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStepAssign
-        + ZnxNormalizeMiddleStepAssign,
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxExtractDigitAddMul,
     BE::BufMut<'r>: HostDataMut,
     BE::BufRef<'a>: HostDataRef,
 {
@@ -195,13 +218,8 @@ fn vec_znx_normalize_coeff_inter_base2k<'r, 'a, BE>(
         BE::znx_normalize_middle_step::<true>(base2k, lsh_pos, res.at_mut(res_col, res_start - j - 1), &src, carry);
     }
 
-    for j in 0..res_end {
-        res.at_mut(res_col, res_end - j - 1).fill(0);
-        if j == res_end - 1 {
-            BE::znx_normalize_final_step_assign(base2k, lsh_pos, res.at_mut(res_col, res_end - j - 1), carry);
-        } else {
-            BE::znx_normalize_middle_step_assign(base2k, lsh_pos, res.at_mut(res_col, res_end - j - 1), carry);
-        }
+    for j in (0..res_end).rev() {
+        BE::znx_extract_digit_mul(base2k, 0, res.at_mut(res_col, j), carry);
     }
 }
 
@@ -274,7 +292,7 @@ fn vec_znx_normalize_coeff_cross_base2k<'r, 'a, BE>(
     let a_end: usize = a_end_bit / a_base2k;
     let a_start: usize = a_start_bit.div_ceil(a_base2k);
 
-    for j in 0..res_size {
+    for j in res_start..res_size {
         res.at_mut(res_col, j).fill(0);
     }
 
@@ -298,6 +316,7 @@ fn vec_znx_normalize_coeff_cross_base2k<'r, 'a, BE>(
 
     let mut res_acc_left: usize = res_base2k;
     let mut res_limb: usize = res_start - 1;
+    let mut initialized = false;
     let mid_range: usize = a_start.saturating_sub(a_end);
 
     'outer: for j in 0..mid_range {
@@ -323,7 +342,18 @@ fn vec_znx_normalize_coeff_cross_base2k<'r, 'a, BE>(
 
             if a_take != 0 {
                 let scale: usize = res_base2k - res_acc_left;
-                BE::znx_extract_digit_addmul(a_take, scale, res_slice, a_norm);
+                if a_take == res_acc_left {
+                    if initialized {
+                        BE::znx_extract_digit_addmul_normalize::<false>(a_take, scale, res_base2k, res_slice, a_norm, res_carry);
+                    } else {
+                        BE::znx_extract_digit_addmul_normalize::<true>(a_take, scale, res_base2k, res_slice, a_norm, res_carry);
+                    }
+                } else if initialized {
+                    BE::znx_extract_digit_addmul(a_take, scale, res_slice, a_norm);
+                } else {
+                    BE::znx_extract_digit_mul(a_take, scale, res_slice, a_norm);
+                }
+                initialized = true;
                 a_take_left -= a_take;
                 res_acc_left -= a_take;
             }
@@ -335,9 +365,15 @@ fn vec_znx_normalize_coeff_cross_base2k<'r, 'a, BE>(
                         let scale: usize = res_base2k - res_acc_left;
                         BE::znx_extract_digit_addmul(res_acc_left, scale, res_slice, a_carry);
                     }
-                    BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                    if res_acc_left != 0 {
+                        BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                    }
                     BE::znx_add_assign(res_carry, a_carry);
                     break 'outer;
+                }
+
+                if res_acc_left != 0 {
+                    BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
                 }
 
                 if res_limb == 0 {
@@ -346,6 +382,7 @@ fn vec_znx_normalize_coeff_cross_base2k<'r, 'a, BE>(
 
                 res_acc_left += res_base2k;
                 res_limb -= 1;
+                initialized = false;
             }
 
             if a_take_left == 0 {
@@ -357,12 +394,8 @@ fn vec_znx_normalize_coeff_cross_base2k<'r, 'a, BE>(
 
     if res_end != 0 {
         let carry_to_use = if a_start == a_end { a_carry } else { res_carry };
-        for j in 0..res_end {
-            if j == res_end - 1 {
-                BE::znx_normalize_final_step_assign(res_base2k, 0, res.at_mut(res_col, res_end - j - 1), carry_to_use);
-            } else {
-                BE::znx_normalize_middle_step_assign(res_base2k, 0, res.at_mut(res_col, res_end - j - 1), carry_to_use);
-            }
+        for j in (0..res_end).rev() {
+            BE::znx_extract_digit_mul(res_base2k, 0, res.at_mut(res_col, j), carry_to_use);
         }
     }
 }
@@ -396,7 +429,24 @@ pub fn vec_znx_normalize<'r, 'a, BE>(
     BE::BufRef<'a>: HostDataRef,
 {
     let n = res.n();
-    vec_znx_normalize_range::<BE>(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, 0, n, carry)
+    if res_base2k != a_base2k && n > 512 {
+        for start in (0..n).step_by(512) {
+            vec_znx_normalize_range::<BE>(
+                res,
+                res_base2k,
+                res_offset,
+                res_col,
+                a,
+                a_base2k,
+                a_col,
+                start,
+                512.min(n - start),
+                carry,
+            );
+        }
+    } else {
+        vec_znx_normalize_range::<BE>(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, 0, n, carry);
+    }
 }
 
 /// [`vec_znx_normalize`] restricted to `[coeff_start, coeff_start + coeff_len)`;
@@ -462,8 +512,16 @@ fn vec_znx_normalize_range<'r, 'a, BE>(
 ///
 /// # Safety
 ///
-/// `res_ptr` must address a valid `n * cols * size` allocation. Any live calls
-/// using the same allocation must write disjoint coefficient ranges.
+/// `res_ptr` must be non-null, aligned for `i64`, and address at least
+/// `n * cols * size` initialized `i64` values; layout arithmetic must not overflow.
+/// The source must have valid initialized storage, degree `n`, and column `a_col`.
+/// Require `res_col < cols`, `coeff_start <= n`, `coeff_len <= n - coeff_start`,
+/// and at least `3 * coeff_len` private scratch words in `carry`.
+///
+/// For every destination limb, the selected coefficient range must be exclusively
+/// writable for this call and must not overlap source or scratch storage. Concurrent
+/// calls may share the destination allocation only with disjoint coefficient ranges.
+/// Source reads must remain immutable, and scratch must not overlap the source.
 #[allow(clippy::too_many_arguments)]
 #[doc(hidden)]
 pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
@@ -505,6 +563,22 @@ pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
         assert!(carry.len() >= 3 * coeff_len);
     }
     let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
+    let a_bits = (a.size() * a_base2k) as i64;
+    let res_bits = (size * res_base2k) as i64;
+    if a.size() == 0 || a_base2k > 63 || res_base2k > 63 || res_offset < a_bits - res_bits || res_offset >= a_bits {
+        for i in 0..coeff_len {
+            normalize_exact::<true, _, _>(
+                |j| a.at(a_col, j)[coeff_start + i] as i128,
+                a.size(),
+                a_base2k,
+                size,
+                res_base2k,
+                res_offset,
+                |j, digit| res.at_mut(j)[i] = digit,
+            );
+        }
+        return;
+    }
     match res_base2k == a_base2k {
         true => vec_znx_normalize_inter_base2k::<BE>(
             res_base2k,
@@ -550,7 +624,8 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStepCarryOnly
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStepAssign
-        + ZnxNormalizeMiddleStepAssign,
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxExtractDigitAddMul,
     BE::BufRef<'a>: HostDataRef,
 {
     let (lo, hi) = (coeff_start, coeff_start + coeff_len);
@@ -611,13 +686,8 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
     }
 
     // Propagates the carry over the non-overlapping limbs between res and a
-    for j in 0..res_end {
-        BE::znx_zero(res.at_mut(res_end - j - 1));
-        if j == res_end - 1 {
-            BE::znx_normalize_final_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
-        } else {
-            BE::znx_normalize_middle_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
-        }
+    for j in (0..res_end).rev() {
+        BE::znx_extract_digit_mul(base2k, 0, res.at_mut(j), carry);
     }
 }
 
@@ -686,11 +756,8 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
     let a_end: usize = a_end_bit / a_base2k;
     let a_start: usize = a_start_bit.div_ceil(a_base2k);
 
-    // Zero all limbs of `res`. Unlike the simple case
-    // where `res_base2k` is equal to `a_base2k`, we also
-    // need to ensure that the limbs starting from `res_end`
-    // are zero.
-    for j in 0..res_size {
+    // Every overlapping limb is overwritten by its first extraction.
+    for j in res_start..res_size {
         BE::znx_zero(res.at_mut(j));
     }
 
@@ -721,6 +788,7 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
 
     // Starting limb of `res`.
     let mut res_limb: usize = res_start - 1;
+    let mut initialized = false;
 
     // How many limbs of `a` overlap with `res` (after taking into account the offset).
     let mid_range: usize = a_start.saturating_sub(a_end);
@@ -779,7 +847,18 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
             if a_take != 0 {
                 // Extract `a_take` bits from a_norm and accumulates them on `res_slice`.
                 let scale: usize = res_base2k - res_acc_left;
-                BE::znx_extract_digit_addmul(a_take, scale, res_slice, a_norm);
+                if a_take == res_acc_left {
+                    if initialized {
+                        BE::znx_extract_digit_addmul_normalize::<false>(a_take, scale, res_base2k, res_slice, a_norm, res_carry);
+                    } else {
+                        BE::znx_extract_digit_addmul_normalize::<true>(a_take, scale, res_base2k, res_slice, a_norm, res_carry);
+                    }
+                } else if initialized {
+                    BE::znx_extract_digit_addmul(a_take, scale, res_slice, a_norm);
+                } else {
+                    BE::znx_extract_digit_mul(a_take, scale, res_slice, a_norm);
+                }
+                initialized = true;
                 a_take_left -= a_take;
                 res_acc_left -= a_take;
             }
@@ -794,7 +873,7 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
                 // the normalization to ensure the `res-offset` overflowing bits of `a`
                 // are in the MSB of `res` instead of being discarded.
                 if a_limb == 0 && a_take_left == 0 {
-                    // TODO: prove no overflow can happen here (should not intuitively)
+                    // Exhausting a normalized source leaves 0 or 1; its carry has room for that unit.
                     BE::znx_add_assign(a_carry, a_norm);
 
                     // Usual case where for example
@@ -813,10 +892,12 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
                         BE::znx_extract_digit_addmul(res_acc_left, scale, res_slice, a_carry);
                     }
 
-                    BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                    if res_acc_left != 0 {
+                        BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                    }
 
                     // Previous step might not consume all bits of a_carry
-                    // TODO: prove no overflow can happen here
+                    // Extraction reduces a_carry before adding the bounded result carry.
                     BE::znx_add_assign(res_carry, a_carry);
 
                     // We are done, so breaks out of the loop (yes we are at a[0], but
@@ -825,12 +906,17 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
                 }
 
                 // If we reached the last limb of res
+                if res_acc_left != 0 {
+                    BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                }
+
                 if res_limb == 0 {
                     break 'outer;
                 }
 
                 res_acc_left += res_base2k;
                 res_limb -= 1;
+                initialized = false;
             }
 
             // If a_norm is exhausted, breaks the inner loop.
@@ -860,12 +946,8 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
         // the carry of a[0].
         let carry_to_use = if a_start == a_end { a_carry } else { res_carry };
 
-        for j in 0..res_end {
-            if j == res_end - 1 {
-                BE::znx_normalize_final_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
-            } else {
-                BE::znx_normalize_middle_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
-            }
+        for j in (0..res_end).rev() {
+            BE::znx_extract_digit_mul(res_base2k, 0, res.at_mut(j), carry_to_use);
         }
     }
 }
@@ -906,8 +988,14 @@ fn vec_znx_normalize_assign_range<'r, BE>(
 ///
 /// # Safety
 ///
-/// `res_ptr` must address a valid `n * cols * size` allocation. Any live calls
-/// using the same allocation must write disjoint coefficient ranges.
+/// `res_ptr` must be non-null, aligned for `i64`, and address at least
+/// `n * cols * size` initialized `i64` values; layout arithmetic must not overflow.
+/// Require `res_col < cols`, `coeff_start <= n`, `coeff_len <= n - coeff_start`,
+/// and at least `coeff_len` private scratch words in `carry`.
+///
+/// For every limb, the selected coefficient range must be exclusively writable
+/// and must not overlap scratch storage. Concurrent calls may share the allocation
+/// only with disjoint coefficient ranges.
 #[allow(clippy::too_many_arguments)]
 #[doc(hidden)]
 pub unsafe fn vec_znx_normalize_assign_range_raw<BE>(
@@ -928,6 +1016,9 @@ pub unsafe fn vec_znx_normalize_assign_range_raw<BE>(
         assert!(res_col < cols);
         assert!(coeff_start + coeff_len <= n);
         assert!(carry.len() >= coeff_len);
+    }
+    if base2k == 64 {
+        return;
     }
     let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
     let carry = &mut carry[..coeff_len];
@@ -1171,6 +1262,612 @@ fn test_vec_znx_normalize_inter_base2k() {
                 let err_log2: f64 = f64::try_from(err).unwrap_or(0.0).max(1e-60_f64).log2();
 
                 assert!(err_log2 <= -(out_prec as f64), "{} {}", err_log2, -(out_prec as f64))
+            }
+        }
+    }
+}
+
+#[test]
+fn test_vec_znx_normalize_limb_bounds() {
+    use crate::{
+        FFT64Ref,
+        layouts::{FillUniform, VecZnx, VecZnxToBackendMut, VecZnxToBackendRef, ZnxView},
+        source::Source,
+    };
+    let n: usize = 8;
+    let mut carry: Vec<i64> = vec![0i64; vec_znx_normalize_tmp_bytes(n) / size_of::<i64>()];
+    let mut source: Source = Source::new([1u8; 32]);
+    for in_base2k in 1..=51usize {
+        for out_base2k in 1..=51usize {
+            for offset in [-(in_base2k as i64), -3, -1, 0, 1, 3, in_base2k as i64] {
+                for in_size in 1..=4usize {
+                    for out_size in 1..=4usize {
+                        let mut want: VecZnx<Vec<u8>, i64> = alloc_host_vec_znx(n, 1, in_size);
+                        want.fill_uniform(62, &mut source);
+                        let mut have: VecZnx<Vec<u8>, i64> = alloc_host_vec_znx(n, 1, out_size);
+                        vec_znx_normalize::<FFT64Ref>(
+                            &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut have),
+                            out_base2k,
+                            offset,
+                            0,
+                            &<VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&want),
+                            in_base2k,
+                            0,
+                            &mut carry,
+                        );
+                        let bound: i64 = 1 << (out_base2k - 1);
+                        for j in 0..out_size {
+                            assert!(
+                                have.at(0, j).iter().all(|x| (-bound..bound).contains(x)),
+                                "in_base2k={in_base2k} out_base2k={out_base2k} offset={offset} in_size={in_size} out_size={out_size} limb={j}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Exact fixed-point quantization, with ties toward positive infinity.
+#[cfg(test)]
+pub(crate) fn normalize_integer_oracle(a: &[i128], a_base2k: usize, res_base2k: usize, res_size: usize, offset: i64) -> Vec<i64> {
+    use dashu_int::IBig;
+    let mut value = IBig::ZERO;
+    for &limb in a {
+        value = (value << a_base2k) + IBig::from(limb);
+    }
+    let shift = res_size as i64 * res_base2k as i64 + offset - a.len() as i64 * a_base2k as i64;
+    if shift >= 0 {
+        value <<= shift as usize;
+    } else {
+        let drop = (-shift) as usize;
+        value = (value + (IBig::ONE << (drop - 1))) >> drop;
+    }
+    let radix = IBig::ONE << res_base2k;
+    let half = IBig::ONE << (res_base2k - 1);
+    let mut result = vec![0; res_size];
+    for limb in result.iter_mut().rev() {
+        let next = (&value + &half) >> res_base2k;
+        *limb = i64::try_from(&value - &next * &radix).unwrap();
+        value = next;
+    }
+    result
+}
+
+#[cfg(test)]
+fn check_normalize_integer(a: &[i128], a_base2k: usize, res_base2k: usize, res_size: usize, offset: i64) {
+    use crate::{
+        FFT64Ref,
+        layouts::{VecZnx, VecZnxToBackendMut, VecZnxToBackendRef},
+    };
+    let mut input = alloc_host_vec_znx(1, 1, a.len());
+    for (j, &x) in a.iter().enumerate() {
+        input.at_mut(0, j)[0] = x as i64;
+    }
+    let mut output = alloc_host_vec_znx(1, 1, res_size);
+    for j in 0..res_size {
+        output.at_mut(0, j)[0] = 12345;
+    }
+    vec_znx_normalize::<FFT64Ref>(
+        &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut output),
+        res_base2k,
+        offset,
+        0,
+        &<VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&input),
+        a_base2k,
+        0,
+        &mut [91; 3],
+    );
+    let have: Vec<i64> = (0..res_size).map(|j| output.at(0, j)[0]).collect();
+    assert_eq!(
+        have,
+        normalize_integer_oracle(a, a_base2k, res_base2k, res_size, offset),
+        "a={a:?}, a_base2k={a_base2k}, res_base2k={res_base2k}, res_size={res_size}, offset={offset}"
+    );
+}
+
+#[test]
+fn test_normalize_exact_regressions() {
+    check_normalize_integer(&[], 2, 3, 1, -1);
+    check_normalize_integer(&[0, 1, 2], 2, 2, 1, 0);
+    check_normalize_integer(&[9], 2, 2, 1, -4);
+    check_normalize_integer(&[9], 2, 3, 1, -4);
+    check_normalize_integer(&[-1], 3, 2, 1, 0);
+    check_normalize_integer(&[1i128 << 62], 2, 3, 1, -5);
+}
+
+#[test]
+fn test_normalize_integer_input_bound() {
+    let mut state = 0x123456789abcdefu64;
+    for a_base2k in 1..=62 {
+        for res_base2k in 1..=62 {
+            for a_size in 1..=8 {
+                let a: Vec<i128> = (0..a_size)
+                    .map(|j| {
+                        state ^= state << 13;
+                        state ^= state >> 7;
+                        state ^= state << 17;
+                        match j % 4 {
+                            0 => -(1i128 << 62),
+                            1 => 1i128 << 62,
+                            _ => (state as i64 >> 1) as i128,
+                        }
+                    })
+                    .collect();
+                for a in [a, vec![-(1i128 << 62); a_size], vec![1i128 << 62; a_size]] {
+                    for res_size in [1, 3, 8] {
+                        let bracket = (a_size * a_base2k + res_size * res_base2k) as i64;
+                        for offset in [-bracket, -(a_base2k as i64) - 1, -1, 0, 1, a_base2k as i64, bracket] {
+                            check_normalize_integer(&a, a_base2k, res_base2k, res_size, offset);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Reads the two's-complement bits of the exact radix-weighted input integer.
+pub(crate) struct NormalizationBits<F, const NARROW: bool> {
+    source: F,
+    left: usize,
+    base2k: usize,
+    carry: i128,
+    digit: u64,
+    available: usize,
+}
+
+impl<F: FnMut(usize) -> i128, const NARROW: bool> NormalizationBits<F, NARROW> {
+    pub(crate) fn new(source: F, size: usize, base2k: usize) -> Self {
+        Self {
+            source,
+            left: size,
+            base2k,
+            carry: 0,
+            digit: 0,
+            available: 0,
+        }
+    }
+
+    fn refill(&mut self) {
+        let mask = (1u64 << self.base2k) - 1;
+        if self.left != 0 {
+            self.left -= 1;
+            let a = (self.source)(self.left);
+            let low = (a as u64 & mask) + (self.carry as u64 & mask);
+            self.carry = if NARROW {
+                ((a as i64 >> self.base2k) + (self.carry as i64 >> self.base2k) + (low >> self.base2k) as i64) as i128
+            } else {
+                (a >> self.base2k) + (self.carry >> self.base2k) + (low >> self.base2k) as i128
+            };
+            self.digit = low & mask;
+        } else {
+            self.digit = self.carry as u64 & mask;
+            self.carry = if NARROW {
+                (self.carry as i64 >> self.base2k) as i128
+            } else {
+                self.carry >> self.base2k
+            };
+        }
+        self.available = self.base2k;
+    }
+
+    fn read(&mut self, mut count: usize) -> u64 {
+        let mut value = 0;
+        let mut written = 0;
+        while count != 0 {
+            if self.available == 0 {
+                self.refill();
+            }
+            let take = count.min(self.available);
+            value |= (self.digit & ((1u64 << take) - 1)) << written;
+            self.digit >>= take;
+            self.available -= take;
+            count -= take;
+            written += take;
+        }
+        value
+    }
+
+    fn skip(&mut self, mut count: i128) {
+        while count != 0 {
+            if self.available == 0 {
+                if self.left == 0 && (self.carry == 0 || self.carry == -1) {
+                    return;
+                }
+                self.refill();
+            }
+            let take = count.min(self.available as i128) as usize;
+            self.digit >>= take;
+            self.available -= take;
+            count -= take as i128;
+        }
+    }
+}
+
+/// Quantizes once at the destination precision, then emits centered digits.
+/// `NARROW` requires every source coefficient to fit in i64.
+pub(crate) fn normalize_exact<const NARROW: bool, F: FnMut(usize) -> i128, G: FnMut(usize, i64)>(
+    source: F,
+    a_size: usize,
+    a_base2k: usize,
+    res_size: usize,
+    res_base2k: usize,
+    offset: i64,
+    mut output: G,
+) {
+    if a_base2k > 63 || res_base2k > 63 {
+        normalize_exact_wide(source, a_size, a_base2k, res_size, res_base2k, offset, output);
+        return;
+    }
+    let mut bits = NormalizationBits::<_, NARROW>::new(source, a_size, a_base2k);
+    let drop = a_size as i128 * a_base2k as i128 - res_size as i128 * res_base2k as i128 - offset as i128;
+    let mut carry = 0u64;
+    let mut padding = 0i128;
+    if drop > 0 {
+        bits.skip(drop - 1);
+        carry = bits.read(1);
+    } else {
+        padding = -drop;
+    }
+    let half = 1u64 << (res_base2k - 1);
+    for j in (0..res_size).rev() {
+        let zeroes = padding.min(res_base2k as i128) as usize;
+        padding -= zeroes as i128;
+        let raw = bits.read(res_base2k - zeroes) << zeroes;
+        let value = raw + carry;
+        carry = (value + half) >> res_base2k;
+        output(j, (value as i128 - ((carry as i128) << res_base2k)) as i64);
+    }
+}
+
+// Preserves the wider source radices and base-64 output supported by NTT.
+fn normalize_exact_wide<F: FnMut(usize) -> i128, G: FnMut(usize, i64)>(
+    mut source: F,
+    a_size: usize,
+    a_base2k: usize,
+    res_size: usize,
+    res_base2k: usize,
+    offset: i64,
+    mut output: G,
+) {
+    assert!((1..=127).contains(&a_base2k));
+    assert!((1..=64).contains(&res_base2k));
+    let mask = (1u128 << a_base2k) - 1;
+    let mut left = a_size;
+    let mut carry = 0i128;
+    let mut pending = 0u128;
+    let mut available = 0usize;
+    let mut read = |mut count: i128, discard: bool| {
+        let mut result = 0u128;
+        let mut written = 0usize;
+        while count != 0 {
+            if available == 0 {
+                if discard && left == 0 && (carry == 0 || carry == -1) {
+                    break;
+                }
+                if left != 0 {
+                    left -= 1;
+                    let a = source(left);
+                    let low = (a as u128 & mask) + (carry as u128 & mask);
+                    carry = (a >> a_base2k) + (carry >> a_base2k) + (low >> a_base2k) as i128;
+                    pending = low & mask;
+                } else {
+                    pending = carry as u128 & mask;
+                    carry >>= a_base2k;
+                }
+                available = a_base2k;
+            }
+            let take = count.min(available as i128) as usize;
+            if !discard {
+                result |= (pending & ((1u128 << take) - 1)) << written;
+                written += take;
+            }
+            pending >>= take;
+            available -= take;
+            count -= take as i128;
+        }
+        result
+    };
+    let drop = a_size as i128 * a_base2k as i128 - res_size as i128 * res_base2k as i128 - offset as i128;
+    let mut rounding = 0u128;
+    let mut padding = 0i128;
+    if drop > 0 {
+        read(drop - 1, true);
+        rounding = read(1, false);
+    } else {
+        padding = -drop;
+    }
+    let half = 1u128 << (res_base2k - 1);
+    for j in (0..res_size).rev() {
+        let zeroes = padding.min(res_base2k as i128) as usize;
+        padding -= zeroes as i128;
+        let value = (read((res_base2k - zeroes) as i128, false) << zeroes) + rounding;
+        rounding = (value + half) >> res_base2k;
+        output(j, (value as i128 - ((rounding as i128) << res_base2k)) as i64);
+    }
+}
+
+#[test]
+fn test_normalize_inter_window_exhaustive() {
+    for k in 1..=62i64 {
+        for a_size in 1..=8i64 {
+            for res_size in 1..=8i64 {
+                let bracket = (a_size + res_size) * k;
+                for offset in -bracket..=bracket {
+                    let q = offset.div_euclid(k);
+                    let lsh = offset.rem_euclid(k);
+                    assert_eq!(offset, q * k + lsh);
+                    let res_end = (-q).clamp(0, res_size);
+                    let res_start = (a_size - q).clamp(0, res_size);
+                    let a_end = q.clamp(0, a_size);
+                    let a_start = (res_size + q).clamp(0, a_size);
+                    assert_eq!(res_start - res_end, a_start - a_end);
+                    for j in 0..a_size {
+                        assert_eq!((a_end..a_start).contains(&j), (0..res_size).contains(&(j - q)));
+                    }
+                    for j in 0..res_size {
+                        assert_eq!((res_end..res_start).contains(&j), (0..a_size).contains(&(j + q)));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_normalize_exhaustive_centered_small() {
+    use dashu_int::IBig;
+
+    use crate::{
+        FFT64Ref,
+        layouts::{VecZnx, VecZnxToBackendMut, VecZnxToBackendRef},
+    };
+    for a_base2k in 1..=6usize {
+        let radix = 1usize << a_base2k;
+        for a_size in 1..=3usize {
+            let mut input = alloc_host_vec_znx(1, 1, a_size);
+            for res_base2k in 1..=6usize {
+                let half = IBig::ONE << (res_base2k - 1);
+                for res_size in 1..=3usize {
+                    let mut output = alloc_host_vec_znx(1, 1, res_size);
+                    let bracket = (a_size * a_base2k + res_size * res_base2k + 1) as i64;
+                    let offsets: Vec<_> = (-bracket..=bracket)
+                        .map(|offset| {
+                            let shift = res_size as i64 * res_base2k as i64 + offset - a_size as i64 * a_base2k as i64;
+                            let rounding = if shift < 0 {
+                                IBig::ONE << (-shift - 1) as usize
+                            } else {
+                                IBig::ZERO
+                            };
+                            (offset, shift, rounding)
+                        })
+                        .collect();
+                    for code in 0..(1usize << (a_size * a_base2k)) {
+                        let mut digits = code;
+                        let mut integer = IBig::ZERO;
+                        for j in 0..a_size {
+                            let digit = (digits & (radix - 1)) as i64 - (radix / 2) as i64;
+                            digits >>= a_base2k;
+                            input.at_mut(0, j)[0] = digit;
+                            integer = (integer << a_base2k) + IBig::from(digit);
+                        }
+                        for (offset, shift, rounding) in &offsets {
+                            vec_znx_normalize::<FFT64Ref>(
+                                &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut output),
+                                res_base2k,
+                                *offset,
+                                0,
+                                &<VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&input),
+                                a_base2k,
+                                0,
+                                &mut [37; 3],
+                            );
+                            let mut expected = if *shift >= 0 {
+                                &integer << *shift as usize
+                            } else {
+                                (&integer + rounding) >> (-shift) as usize
+                            };
+                            for j in (0..res_size).rev() {
+                                let next = (&expected + &half) >> res_base2k;
+                                let digit = i64::try_from(&expected - (&next << res_base2k)).unwrap();
+                                assert_eq!(
+                                    output.at(0, j)[0],
+                                    digit,
+                                    "code={code}, ka={a_base2k}, kr={res_base2k}, sa={a_size}, sr={res_size}, offset={offset}, limb={j}"
+                                );
+                                expected = next;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_normalize_coeff_and_range_integer() {
+    use crate::{
+        FFT64Ref,
+        layouts::{VecZnx, VecZnxToBackendMut, VecZnxToBackendRef},
+    };
+    let n = 35;
+    let mut state = 0x58d719b3ce42a670u64;
+    for a_base2k in 1..=62usize {
+        for res_base2k in [1, 2, 17, 50, 62] {
+            for size in [1, 2, 8] {
+                let mut input = alloc_host_vec_znx(n, 2, size);
+                for j in 0..size {
+                    for x in input.at_mut(1, j) {
+                        state ^= state << 13;
+                        state ^= state >> 7;
+                        state ^= state << 17;
+                        *x = state as i64 >> 1;
+                    }
+                }
+                for offset in [
+                    i64::MIN,
+                    -1001,
+                    -(a_base2k as i64) - 1,
+                    -1,
+                    0,
+                    1,
+                    a_base2k as i64,
+                    1001,
+                    i64::MAX,
+                ] {
+                    let mut whole = alloc_host_vec_znx(n, 2, size);
+                    let mut split = alloc_host_vec_znx(n, 2, size);
+                    for j in 0..size {
+                        whole.at_mut(0, j).fill(93);
+                        split.at_mut(0, j).fill(93);
+                    }
+                    let a = <VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&input);
+                    vec_znx_normalize::<FFT64Ref>(
+                        &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut whole),
+                        res_base2k,
+                        offset,
+                        1,
+                        &a,
+                        a_base2k,
+                        1,
+                        &mut vec![73; 3 * n],
+                    );
+                    for (start, end) in [(17, 35), (1, 8), (0, 1), (8, 17)] {
+                        let mut scratch = vec![83; 3 * (end - start) + 2];
+                        vec_znx_normalize_range::<FFT64Ref>(
+                            &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut split),
+                            res_base2k,
+                            offset,
+                            1,
+                            &a,
+                            a_base2k,
+                            1,
+                            start,
+                            end - start,
+                            &mut scratch[1..3 * (end - start) + 1],
+                        );
+                        assert_eq!(scratch[0], 83);
+                        assert_eq!(*scratch.last().unwrap(), 83);
+                    }
+                    for i in 0..n {
+                        let mut single = alloc_host_vec_znx(1, 1, size);
+                        vec_znx_normalize_coeff::<FFT64Ref>(
+                            &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut single),
+                            res_base2k,
+                            offset,
+                            0,
+                            &a,
+                            a_base2k,
+                            1,
+                            i,
+                            &mut [53; 3],
+                        );
+                        // Extreme offsets reduce to zero without enormous oracle allocations.
+                        let expected = if offset == i64::MIN || offset == i64::MAX {
+                            vec![0; size]
+                        } else {
+                            normalize_integer_oracle(
+                                &(0..size).map(|j| input.at(1, j)[i] as i128).collect::<Vec<_>>(),
+                                a_base2k,
+                                res_base2k,
+                                size,
+                                offset,
+                            )
+                        };
+                        for (j, &digit) in expected.iter().enumerate() {
+                            assert_eq!(
+                                whole.at(1, j)[i],
+                                digit,
+                                "ka={a_base2k}, kr={res_base2k}, size={size}, offset={offset}, i={i}, j={j}"
+                            );
+                            assert_eq!(split.at(1, j)[i], digit);
+                            assert_eq!(single.at(0, j)[0], digit);
+                            assert_eq!(whole.at(0, j)[i], 93);
+                            assert_eq!(split.at(0, j)[i], 93);
+                        }
+                    }
+                }
+                let mut assigned = input.clone();
+                vec_znx_normalize_assign::<FFT64Ref>(
+                    a_base2k,
+                    &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut assigned),
+                    1,
+                    &mut vec![37; n],
+                );
+                let mut coeff_assigned = input.clone();
+                for i in 0..n {
+                    vec_znx_normalize_coeff_assign::<FFT64Ref>(
+                        a_base2k,
+                        &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut coeff_assigned),
+                        1,
+                        i,
+                        &mut [91],
+                    );
+                    let want = normalize_integer_oracle(
+                        &(0..size).map(|j| input.at(1, j)[i] as i128).collect::<Vec<_>>(),
+                        a_base2k,
+                        a_base2k,
+                        size,
+                        0,
+                    );
+                    for (j, &digit) in want.iter().enumerate() {
+                        assert_eq!(assigned.at(1, j)[i], digit);
+                        assert_eq!(coeff_assigned.at(1, j)[i], digit);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_normalize_blocked_matches_single_range() {
+    use crate::{
+        FFT64Ref,
+        layouts::{VecZnx, VecZnxToBackendMut, VecZnxToBackendRef},
+    };
+    let n = 1031;
+    for (a_base2k, res_base2k) in [(17, 19), (51, 50), (62, 1), (1, 62)] {
+        for size in [3, 8] {
+            let mut input = alloc_host_vec_znx(n, 1, size);
+            for j in 0..size {
+                for (i, x) in input.at_mut(0, j).iter_mut().enumerate() {
+                    *x = (i as i64).wrapping_mul(0x31e5cd283792b601).wrapping_add(j as i64) >> 1;
+                }
+            }
+            let a = <VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&input);
+            for offset in [-(a_base2k as i64), 0, 1, a_base2k as i64] {
+                let mut whole = alloc_host_vec_znx(n, 1, size);
+                let mut blocked = alloc_host_vec_znx(n, 1, size);
+                let mut carry = vec![31; 3 * n];
+                vec_znx_normalize_range::<FFT64Ref>(
+                    &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut whole),
+                    res_base2k,
+                    offset,
+                    0,
+                    &a,
+                    a_base2k,
+                    0,
+                    0,
+                    n,
+                    &mut carry,
+                );
+                vec_znx_normalize::<FFT64Ref>(
+                    &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut blocked),
+                    res_base2k,
+                    offset,
+                    0,
+                    &a,
+                    a_base2k,
+                    0,
+                    &mut carry,
+                );
+                for j in 0..size {
+                    assert_eq!(whole.at(0, j), blocked.at(0, j));
+                }
             }
         }
     }

--- a/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
+++ b/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
@@ -29,6 +29,22 @@ pub fn vec_znx_normalize_tmp_bytes(n: usize) -> usize {
     3 * n * size_of::<i64>()
 }
 
+#[inline]
+pub(crate) fn normalize_needs_exact(a_size: usize, a_base2k: usize, res_size: usize, res_base2k: usize, offset: i64) -> bool {
+    if a_size == 0 || res_size == 0 || a_base2k > 63 || res_base2k > 63 {
+        return true;
+    }
+    let a_bits = (a_size * a_base2k) as i64;
+    let res_bits = (res_size * res_base2k) as i64;
+    // Dropping at most one same-base limb rounds only in the first carry step.
+    let min_offset = if a_base2k == res_base2k {
+        (a_bits - a_base2k as i64) - res_bits
+    } else {
+        a_bits - res_bits
+    };
+    offset < min_offset || offset >= a_bits
+}
+
 pub(crate) struct VecZnxRangeMut<'a> {
     ptr: *mut i64,
     n: usize,
@@ -87,9 +103,7 @@ pub fn vec_znx_normalize_coeff<'r, 'a, BE>(
     BE::BufMut<'r>: HostDataMut,
     BE::BufRef<'a>: HostDataRef,
 {
-    let a_bits = (a.size() * a_base2k) as i64;
-    let res_bits = (res.size() * res_base2k) as i64;
-    if a.size() == 0 || a_base2k > 63 || res_base2k > 63 || res_offset < a_bits - res_bits || res_offset >= a_bits {
+    if normalize_needs_exact(a.size(), a_base2k, res.size(), res_base2k, res_offset) {
         normalize_exact::<true, _, _>(
             |j| a.at(a_col, j)[a_coeff] as i128,
             a.size(),
@@ -563,9 +577,7 @@ pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
         assert!(carry.len() >= 3 * coeff_len);
     }
     let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
-    let a_bits = (a.size() * a_base2k) as i64;
-    let res_bits = (size * res_base2k) as i64;
-    if a.size() == 0 || a_base2k > 63 || res_base2k > 63 || res_offset < a_bits - res_bits || res_offset >= a_bits {
+    if normalize_needs_exact(a.size(), a_base2k, size, res_base2k, res_offset) {
         for i in 0..coeff_len {
             normalize_exact::<true, _, _>(
                 |j| a.at(a_col, j)[coeff_start + i] as i128,
@@ -1370,6 +1382,7 @@ fn check_normalize_integer(a: &[i128], a_base2k: usize, res_base2k: usize, res_s
 #[test]
 fn test_normalize_exact_regressions() {
     check_normalize_integer(&[], 2, 3, 1, -1);
+    check_normalize_integer(&[1], 2, 2, 0, 0);
     check_normalize_integer(&[0, 1, 2], 2, 2, 1, 0);
     check_normalize_integer(&[9], 2, 2, 1, -4);
     check_normalize_integer(&[9], 2, 3, 1, -4);
@@ -1398,7 +1411,19 @@ fn test_normalize_integer_input_bound() {
                 for a in [a, vec![-(1i128 << 62); a_size], vec![1i128 << 62; a_size]] {
                     for res_size in [1, 3, 8] {
                         let bracket = (a_size * a_base2k + res_size * res_base2k) as i64;
-                        for offset in [-bracket, -(a_base2k as i64) - 1, -1, 0, 1, a_base2k as i64, bracket] {
+                        let gap = (a_size * a_base2k) as i64 - (res_size * res_base2k) as i64;
+                        for offset in [
+                            -bracket,
+                            -(a_base2k as i64) - 1,
+                            -1,
+                            0,
+                            1,
+                            a_base2k as i64,
+                            bracket,
+                            gap - a_base2k as i64 - 1,
+                            gap - a_base2k as i64,
+                            gap - 1,
+                        ] {
                             check_normalize_integer(&a, a_base2k, res_base2k, res_size, offset);
                         }
                     }
@@ -1711,6 +1736,7 @@ fn test_normalize_coeff_and_range_integer() {
                     i64::MIN,
                     -1001,
                     -(a_base2k as i64) - 1,
+                    -(a_base2k as i64),
                     -1,
                     0,
                     1,

--- a/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
+++ b/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
@@ -1642,23 +1642,72 @@ fn test_normalize_inter_window_exhaustive() {
 }
 
 #[test]
-fn test_normalize_exhaustive_centered_small() {
+fn test_normalize_centered_boundaries() {
+    check_normalize_centered(false);
+}
+
+#[test]
+#[ignore = "285 million cases; run explicitly with --release --ignored"]
+fn test_normalize_exhaustive_centered_full() {
+    check_normalize_centered(true);
+}
+
+#[cfg(test)]
+fn check_normalize_centered(exhaustive: bool) {
     use dashu_int::IBig;
 
     use crate::{
         FFT64Ref,
         layouts::{VecZnx, VecZnxToBackendMut, VecZnxToBackendRef},
     };
-    for a_base2k in 1..=6usize {
-        let radix = 1usize << a_base2k;
+    let bases = if exhaustive {
+        (1..=6usize).collect::<Vec<_>>()
+    } else {
+        vec![1, 2, 17, 19, 21, 50, 51, 61, 62]
+    };
+    for &a_base2k in &bases {
+        let half_input = 1i64 << (a_base2k - 1);
+        let alphabet = if exhaustive {
+            (-half_input..half_input).collect::<Vec<_>>()
+        } else {
+            let mut digits = vec![-half_input, -half_input + 1, -1, 0, 1, half_input - 1];
+            digits.retain(|x| (-half_input..half_input).contains(x));
+            digits.sort_unstable();
+            digits.dedup();
+            digits
+        };
         for a_size in 1..=3usize {
             let mut input = alloc_host_vec_znx(1, 1, a_size);
-            for res_base2k in 1..=6usize {
+            for &res_base2k in &bases {
                 let half = IBig::ONE << (res_base2k - 1);
                 for res_size in 1..=3usize {
                     let mut output = alloc_host_vec_znx(1, 1, res_size);
                     let bracket = (a_size * a_base2k + res_size * res_base2k + 1) as i64;
-                    let offsets: Vec<_> = (-bracket..=bracket)
+                    let gap = (a_size * a_base2k) as i64 - (res_size * res_base2k) as i64;
+                    let offsets = if exhaustive {
+                        (-bracket..=bracket).collect::<Vec<_>>()
+                    } else {
+                        let k = a_base2k as i64;
+                        let mut offsets = vec![
+                            -bracket,
+                            -k,
+                            -1,
+                            0,
+                            1,
+                            k,
+                            bracket,
+                            gap - k - 1,
+                            gap - k,
+                            gap - 1,
+                            gap,
+                            gap + 1,
+                        ];
+                        offsets.sort_unstable();
+                        offsets.dedup();
+                        offsets
+                    };
+                    let offsets: Vec<_> = offsets
+                        .into_iter()
                         .map(|offset| {
                             let shift = res_size as i64 * res_base2k as i64 + offset - a_size as i64 * a_base2k as i64;
                             let rounding = if shift < 0 {
@@ -1669,12 +1718,12 @@ fn test_normalize_exhaustive_centered_small() {
                             (offset, shift, rounding)
                         })
                         .collect();
-                    for code in 0..(1usize << (a_size * a_base2k)) {
+                    for code in 0..alphabet.len().pow(a_size as u32) {
                         let mut digits = code;
                         let mut integer = IBig::ZERO;
                         for j in 0..a_size {
-                            let digit = (digits & (radix - 1)) as i64 - (radix / 2) as i64;
-                            digits >>= a_base2k;
+                            let digit = alphabet[digits % alphabet.len()];
+                            digits /= alphabet.len();
                             input.at_mut(0, j)[0] = digit;
                             integer = (integer << a_base2k) + IBig::from(digit);
                         }

--- a/poulpy-cpu-ref/src/test_suite/mod.rs
+++ b/poulpy-cpu-ref/src/test_suite/mod.rs
@@ -1,0 +1,4 @@
+//! Kernel parity tests shared by CPU backend crates.
+
+pub mod normalization;
+pub mod normalization_i128;

--- a/poulpy-cpu-ref/src/test_suite/normalization.rs
+++ b/poulpy-cpu-ref/src/test_suite/normalization.rs
@@ -18,7 +18,7 @@ where
         + ZnxNormalizeMiddleStepSub
         + ZnxNormalizeFinalStepSub
         + ZnxNormalizeFinalStepAssign
-        + ZnxExtractDigitAddMul
+        + I64NormalizeOps
         + ZnxNormalizeDigit,
 {
     let steps: [(Step, Step); 8] = [

--- a/poulpy-cpu-ref/src/test_suite/normalization_i128.rs
+++ b/poulpy-cpu-ref/src/test_suite/normalization_i128.rs
@@ -1,8 +1,10 @@
 //! Wide fused normalization parity across backend implementations.
 
-use crate::reference::znx::{ZnxExtractDigitAddMulI128, get_digit_i64, znx_extract_digit_addmul_normalize_i128_ref};
+use crate::reference::ntt4x30::I128NormalizeOps;
 
-pub fn test_i128_normalize_fused<BE: ZnxExtractDigitAddMulI128>() {
+use crate::reference::znx::{get_digit_i64, znx_extract_digit_addmul_normalize_i128_ref};
+
+pub fn test_i128_normalize_fused<BE: I128NormalizeOps>() {
     let idft_bound = (1_073_479_681i128 * 1_071_513_601 * 1_070_727_169 * 1_068_236_801 - 1) / 2;
     for res_base2k in 1..=63 {
         for base2k in 1..=res_base2k {

--- a/poulpy-cpu-ref/src/tests.rs
+++ b/poulpy-cpu-ref/src/tests.rs
@@ -335,3 +335,430 @@ poulpy_core::core_parity_test_suite! {
         glwe_tensor => poulpy_core::test_suite::parity::test_glwe_tensor_parity,
     }
 }
+
+fn vec_znx_big_normalize_limb_bounds<BE>(module: &Module<BE>)
+where
+    BE: poulpy_hal::test_suite::TestBackend,
+    BE::OwnedBuf: poulpy_hal::layouts::HostDataRef,
+    Module<BE>: poulpy_hal::api::VecZnxBigAlloc<BE>
+        + poulpy_hal::api::VecZnxBigFromSmallBackend<BE>
+        + poulpy_hal::api::VecZnxBigNormalize<BE>
+        + poulpy_hal::api::VecZnxBigNormalizeTmpBytes,
+    poulpy_hal::layouts::ScratchOwned<BE>: poulpy_hal::api::ScratchOwnedAlloc<BE>,
+{
+    use poulpy_hal::{
+        api::{ScratchOwnedAlloc, VecZnxBigAlloc, VecZnxBigFromSmallBackend, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes},
+        layouts::{
+            FillUniform, HostBytesBackend, ScratchOwned, VecZnx, VecZnxBigToBackendMut, VecZnxBigToBackendRef,
+            VecZnxToBackendMut, VecZnxToBackendRef, ZnxView,
+        },
+        source::Source,
+        test_suite::upload_vec_znx,
+    };
+    let module_host: Module<HostBytesBackend> = Module::<HostBytesBackend>::new(module.n() as u64);
+    let mut source = Source::new([2u8; 32]);
+    let mut scratch: ScratchOwned<BE> = ScratchOwned::alloc(module.vec_znx_big_normalize_tmp_bytes());
+    for a_base2k in 1..=51usize {
+        for res_base2k in 1..=51usize {
+            for offset in [-(a_base2k as i64), -3, -1, 0, 1, 3, a_base2k as i64] {
+                for a_size in 1..=3usize {
+                    for res_size in 1..=3usize {
+                        let mut a = module_host.vec_znx_alloc(1, a_size);
+                        a.fill_uniform(63, &mut source);
+                        let uploaded = upload_vec_znx::<BE>(&a);
+                        let mut big = module.vec_znx_big_alloc(1, a_size);
+                        module.vec_znx_big_from_small_backend(
+                            &mut big.to_backend_mut(),
+                            0,
+                            &<VecZnx<BE::OwnedBuf, i64> as VecZnxToBackendRef<BE>>::to_backend_ref(&uploaded),
+                            0,
+                        );
+                        let mut res = module.vec_znx_alloc(1, res_size);
+                        module.vec_znx_big_normalize(
+                            &mut <VecZnx<BE::OwnedBuf, i64> as VecZnxToBackendMut<BE>>::to_backend_mut(&mut res),
+                            res_base2k,
+                            offset,
+                            0,
+                            &big.to_backend_ref(),
+                            a_base2k,
+                            0,
+                            &mut scratch.arena(),
+                        );
+                        let bound: i64 = 1 << (res_base2k - 1);
+                        for j in 0..res_size {
+                            assert!(
+                                res.at(0, j).iter().all(|x| (-bound..bound).contains(x)),
+                                "a_base2k={a_base2k} res_base2k={res_base2k} offset={offset} a_size={a_size} res_size={res_size} limb={j}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_vec_znx_big_normalize_limb_bounds_fft64_ref() {
+    vec_znx_big_normalize_limb_bounds(&Module::<FFT64Ref>::new(8));
+}
+
+#[test]
+fn test_vec_znx_big_normalize_limb_bounds_ntt4x30_ref() {
+    vec_znx_big_normalize_limb_bounds(&Module::<NTT4x30Ref>::new(8));
+}
+
+const NORMALIZE_IDFT_BOUND: i128 = (1_073_479_681i128 * 1_071_513_601 * 1_070_727_169 * 1_068_236_801 - 1) / 2;
+
+#[test]
+fn test_vec_znx_big_normalize_input_bound_integer() {
+    use crate::reference::{
+        ntt4x30::ntt4x30_vec_znx_big_normalize,
+        vec_znx::{normalize_integer_oracle, vec_znx_normalize},
+    };
+    use poulpy_hal::layouts::{VecZnx, VecZnxBig, VecZnxToBackendMut, VecZnxToBackendRef, ZnxView, ZnxViewMut};
+
+    const N: usize = 8;
+    let values = [
+        -(1i128 << 126),
+        1i128 << 126,
+        -NORMALIZE_IDFT_BOUND,
+        NORMALIZE_IDFT_BOUND,
+        -(1i128 << 62),
+        1i128 << 62,
+        -1,
+        1,
+    ];
+    let mut carry = [0i128; 3 * N];
+    let mut random = 0x123456789abcdef0u128;
+    for a_base2k in 1..=62 {
+        for res_base2k in 1..=62 {
+            for a_size in 0..=8 {
+                let mut input = VecZnxBig::<Vec<u8>, i128, NTT4x30Ref>::from_data(vec![0; 16 * N * a_size], N, 1, a_size);
+                for j in 0..a_size {
+                    for i in 0..N {
+                        random ^= random << 17;
+                        random ^= random >> 29;
+                        random ^= random << 43;
+                        input.at_mut(0, j)[i] = match i {
+                            0..=3 => values[i],
+                            4 => values[4 + j % 2],
+                            5 => (random as i64 >> 1) as i128,
+                            6 => values[j % 2],
+                            _ => random as i128 >> 1,
+                        };
+                    }
+                }
+                let mut small_input = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 8 * N * a_size], N, 1, a_size);
+                for j in 0..a_size {
+                    for i in 0..N {
+                        small_input.at_mut(0, j)[i] = if (4..=5).contains(&i) {
+                            input.at(0, j)[i] as i64
+                        } else {
+                            input.at(0, j)[i] as i64 >> 1
+                        };
+                    }
+                }
+                for res_size in 1..=8 {
+                    let mut output = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 8 * N * res_size], N, 1, res_size);
+                    let mut small_output = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 8 * N * res_size], N, 1, res_size);
+                    let bracket = (a_size * a_base2k + res_size * res_base2k + 128) as i64;
+                    for offset in [-bracket, -(a_base2k as i64) - 1, -1, 0, 1, a_base2k as i64, bracket] {
+                        ntt4x30_vec_znx_big_normalize::<_, _, NTT4x30Ref>(
+                            &mut output,
+                            res_base2k,
+                            offset,
+                            0,
+                            &input,
+                            a_base2k,
+                            0,
+                            &mut carry,
+                        );
+                        vec_znx_normalize::<FFT64Ref>(
+                            &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut small_output),
+                            res_base2k,
+                            offset,
+                            0,
+                            &<VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&small_input),
+                            a_base2k,
+                            0,
+                            &mut [0i64; 3 * N],
+                        );
+                        for i in 4..=5 {
+                            for j in 0..res_size {
+                                assert_eq!(output.at(0, j)[i], small_output.at(0, j)[i]);
+                            }
+                        }
+                        for i in 0..N {
+                            let limbs: Vec<_> = (0..a_size).map(|j| input.at(0, j)[i]).collect();
+                            let want = normalize_integer_oracle(&limbs, a_base2k, res_base2k, res_size, offset);
+                            let got: Vec<_> = (0..res_size).map(|j| output.at(0, j)[i]).collect();
+                            assert_eq!(
+                                got, want,
+                                "ka={a_base2k} kr={res_base2k} a={limbs:?} size={res_size} offset={offset}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_vec_znx_big_normalize_assign_and_ranges() {
+    use crate::reference::ntt4x30::{
+        ntt4x30_vec_znx_big_normalize, ntt4x30_vec_znx_big_normalize_assign, ntt4x30_vec_znx_big_normalize_range_raw,
+        vec_znx_big::{AddOp, SubOp},
+    };
+    use poulpy_hal::layouts::{VecZnx, VecZnxBig, ZnxView, ZnxViewMut};
+    let mut regression_input = VecZnxBig::<Vec<u8>, i128, NTT4x30Ref>::from_data(vec![0; 16], 1, 1, 1);
+    regression_input.at_mut(0, 0)[0] = 3;
+    let mut regression_output = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 24], 1, 1, 3);
+    ntt4x30_vec_znx_big_normalize_assign::<SubOp, _, _, NTT4x30Ref>(
+        &mut regression_output,
+        2,
+        -2,
+        0,
+        &regression_input,
+        1,
+        0,
+        &mut [0; 3],
+    );
+    assert_eq!((0..3).map(|j| regression_output.at(0, j)[0]).collect::<Vec<_>>(), [2, 2, 0]);
+    const N: usize = 17;
+    for a_base2k in [1, 2, 17, 50, 62] {
+        for res_base2k in [1, 2, 19, 51, 62] {
+            for offset in [i64::MIN, -400, -63, -1, 0, 1, 63, 400, i64::MAX] {
+                let mut input = VecZnxBig::<Vec<u8>, i128, NTT4x30Ref>::from_data(vec![0; 16 * N * 3], N, 1, 3);
+                for j in 0..3 {
+                    for i in 0..N {
+                        input.at_mut(0, j)[i] = (NORMALIZE_IDFT_BOUND / (i as i128 + 1)) * if (i + j) % 2 == 0 { -1 } else { 1 };
+                    }
+                }
+                let alloc = || VecZnx::<Vec<u8>, i64>::from_data(vec![0; 8 * N * 3], N, 1, 3);
+                let mut want = alloc();
+                let mut carry = [0i128; 3 * N];
+                ntt4x30_vec_znx_big_normalize::<_, _, NTT4x30Ref>(
+                    &mut want, res_base2k, offset, 0, &input, a_base2k, 0, &mut carry,
+                );
+                let mut split = alloc();
+                let ptr = split.data.as_mut_ptr().cast::<i64>();
+                for (start, len) in [(0, 3), (3, 7), (10, 7)] {
+                    let mut private = vec![0i128; 3 * len];
+                    unsafe {
+                        ntt4x30_vec_znx_big_normalize_range_raw::<_, NTT4x30Ref>(
+                            ptr,
+                            N,
+                            1,
+                            3,
+                            res_base2k,
+                            offset,
+                            0,
+                            &input,
+                            a_base2k,
+                            0,
+                            start,
+                            len,
+                            &mut private,
+                        );
+                    }
+                }
+                assert_eq!(split, want);
+                for sub in [false, true] {
+                    let mut got = alloc();
+                    for j in 0..3 {
+                        got.at_mut(0, j).fill(37);
+                    }
+
+                    if sub {
+                        ntt4x30_vec_znx_big_normalize_assign::<SubOp, _, _, NTT4x30Ref>(
+                            &mut got, res_base2k, offset, 0, &input, a_base2k, 0, &mut carry,
+                        );
+                    } else {
+                        ntt4x30_vec_znx_big_normalize_assign::<AddOp, _, _, NTT4x30Ref>(
+                            &mut got, res_base2k, offset, 0, &input, a_base2k, 0, &mut carry,
+                        );
+                    }
+                    for j in 0..3 {
+                        for i in 0..N {
+                            let expected = if sub { 37 - want.at(0, j)[i] } else { 37 + want.at(0, j)[i] };
+                            assert_eq!(
+                                got.at(0, j)[i],
+                                expected,
+                                "ka={a_base2k} kr={res_base2k} offset={offset} sub={sub}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_i128_normalization_kernel_integer() {
+    use crate::reference::ntt4x30::I128NormalizeOps;
+    use dashu_int::IBig;
+    for base2k in 1..=63 {
+        let half = 1i128 << (base2k - 1);
+        let a = [
+            -(1i128 << 126),
+            1i128 << 126,
+            -NORMALIZE_IDFT_BOUND,
+            NORMALIZE_IDFT_BOUND,
+            -half - 1,
+            -half,
+            half - 1,
+            half,
+            -1,
+            0,
+            1,
+        ];
+        for lsh in 0..base2k {
+            for offset in 0..a.len() {
+                let mut carry: Vec<_> = (0..a.len())
+                    .map(|i| {
+                        let total = IBig::from(a[(i + offset) % a.len()]) << lsh;
+                        i128::try_from((total + IBig::from(half)) >> base2k).unwrap()
+                    })
+                    .collect();
+                let mut want_res = Vec::new();
+                let mut want_carry = Vec::new();
+                for (&input, &previous) in a.iter().zip(&carry) {
+                    let total = (IBig::from(input) << lsh) + IBig::from(previous);
+                    let next = (&total + IBig::from(half)) >> base2k;
+                    want_res.push(i64::try_from(total - (&next << base2k)).unwrap());
+                    want_carry.push(i128::try_from(next).unwrap());
+                }
+                let mut res = vec![0i64; a.len()];
+                <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step(base2k, lsh, &mut res, &a, &mut carry);
+                assert_eq!(res, want_res, "base2k={base2k} lsh={lsh}");
+                assert_eq!(carry, want_carry, "base2k={base2k} lsh={lsh}");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_i128_normalize_fused_reference() {
+    use crate::reference::{
+        ntt4x30::I128NormalizeOps,
+        znx::{ZnxExtractDigitAddMulI128, get_carry_i128, get_digit_i128},
+    };
+    for base2k in 1..=63 {
+        for take in 1..=base2k {
+            let scale = base2k - take;
+            let mut src = [-NORMALIZE_IDFT_BOUND, NORMALIZE_IDFT_BOUND, -1, 0, 1];
+            let mut carry = [-1, 0, -1, 0, 0];
+            let quarter = if base2k > 1 { 1i64 << (base2k - 2) } else { 0 };
+            let mut res = [-quarter, quarter.saturating_sub(1), -1, 0, 1];
+            if base2k == 1 {
+                res.fill(0);
+            }
+            let mut want_src = src;
+            let mut want_carry = carry;
+            let mut want_res = res;
+            for (r, s) in want_res.iter_mut().zip(&mut want_src) {
+                let digit = get_digit_i128(take, *s);
+                *s = get_carry_i128(take, *s, digit);
+                *r = r.wrapping_add((digit as i64).wrapping_shl(scale as u32));
+            }
+            <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step_assign(base2k, 0, &mut want_res, &mut want_carry);
+            <NTT4x30Ref as ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<false>(
+                take, scale, base2k, &mut res, &mut src, &mut carry,
+            );
+            assert_eq!((res, src, carry), (want_res, want_src, want_carry));
+        }
+    }
+}
+
+#[test]
+fn test_vec_znx_big_normalize_wide_radices() {
+    use crate::reference::{
+        ntt4x30::{
+            ntt4x30_vec_znx_big_normalize, ntt4x30_vec_znx_big_normalize_assign,
+            vec_znx_big::{AddOp, SubOp},
+        },
+        vec_znx::normalize_integer_oracle,
+    };
+    use poulpy_hal::layouts::{VecZnx, VecZnxBig, ZnxView, ZnxViewMut};
+    for a_base2k in [1, 63, 64, 65, 126, 127] {
+        for res_base2k in [1, 17, 63, 64] {
+            for size in 1..=3 {
+                let mut input = VecZnxBig::<Vec<u8>, i128, NTT4x30Ref>::from_data(vec![0; 32 * size], 2, 1, size);
+                for j in 0..size {
+                    input
+                        .at_mut(0, j)
+                        .copy_from_slice(&[-NORMALIZE_IDFT_BOUND, NORMALIZE_IDFT_BOUND]);
+                }
+                let mut output = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 16 * size], 2, 1, size);
+                for offset in [-400, -64, -1, 0, 1, 64, 400] {
+                    ntt4x30_vec_znx_big_normalize::<_, _, NTT4x30Ref>(
+                        &mut output,
+                        res_base2k,
+                        offset,
+                        0,
+                        &input,
+                        a_base2k,
+                        0,
+                        &mut [0; 6],
+                    );
+                    for sub in [false, true] {
+                        let mut assigned = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 16 * size], 2, 1, size);
+                        for j in 0..size {
+                            assigned.at_mut(0, j).copy_from_slice(&[-(1i64 << 62), 1i64 << 62]);
+                        }
+                        if sub {
+                            ntt4x30_vec_znx_big_normalize_assign::<SubOp, _, _, NTT4x30Ref>(
+                                &mut assigned,
+                                res_base2k,
+                                offset,
+                                0,
+                                &input,
+                                a_base2k,
+                                0,
+                                &mut [0; 6],
+                            );
+                        } else {
+                            ntt4x30_vec_znx_big_normalize_assign::<AddOp, _, _, NTT4x30Ref>(
+                                &mut assigned,
+                                res_base2k,
+                                offset,
+                                0,
+                                &input,
+                                a_base2k,
+                                0,
+                                &mut [0; 6],
+                            );
+                        }
+                        for i in 0..2 {
+                            let initial = [-(1i64 << 62), 1i64 << 62][i] as i128;
+                            let total: Vec<_> = (0..size)
+                                .map(|j| {
+                                    initial
+                                        + if sub {
+                                            -(output.at(0, j)[i] as i128)
+                                        } else {
+                                            output.at(0, j)[i] as i128
+                                        }
+                                })
+                                .collect();
+                            let stored: Vec<_> = (0..size).map(|j| assigned.at(0, j)[i] as i128).collect();
+                            assert_eq!(
+                                normalize_integer_oracle(&stored, res_base2k, res_base2k, size, 0),
+                                normalize_integer_oracle(&total, res_base2k, res_base2k, size, 0)
+                            );
+                        }
+                    }
+                    for i in 0..2 {
+                        let limbs: Vec<_> = (0..size).map(|j| input.at(0, j)[i]).collect();
+                        let want = normalize_integer_oracle(&limbs, a_base2k, res_base2k, size, offset);
+                        let got: Vec<_> = (0..size).map(|j| output.at(0, j)[i]).collect();
+                        assert_eq!(got, want, "ka={a_base2k} kr={res_base2k} size={size} offset={offset}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/poulpy-cpu-ref/src/tests.rs
+++ b/poulpy-cpu-ref/src/tests.rs
@@ -656,7 +656,7 @@ fn test_i128_normalization_kernel_integer() {
 fn test_i128_normalize_fused_reference() {
     use crate::reference::{
         ntt4x30::I128NormalizeOps,
-        znx::{ZnxExtractDigitAddMulI128, get_carry_i128, get_digit_i128},
+        znx::{get_carry_i128, get_digit_i128},
     };
     for base2k in 1..=63 {
         for take in 1..=base2k {
@@ -677,7 +677,7 @@ fn test_i128_normalize_fused_reference() {
                 *r = r.wrapping_add((digit as i64).wrapping_shl(scale as u32));
             }
             <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step_assign(base2k, 0, &mut want_res, &mut want_carry);
-            <NTT4x30Ref as ZnxExtractDigitAddMulI128>::znx_extract_digit_addmul_normalize_i128::<false>(
+            <NTT4x30Ref as I128NormalizeOps>::znx_extract_digit_addmul_normalize_i128::<false>(
                 take, scale, base2k, &mut res, &mut src, &mut carry,
             );
             assert_eq!((res, src, carry), (want_res, want_src, want_carry));

--- a/poulpy-cpu-ref/src/tests.rs
+++ b/poulpy-cpu-ref/src/tests.rs
@@ -463,7 +463,19 @@ fn test_vec_znx_big_normalize_input_bound_integer() {
                     let mut output = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 8 * N * res_size], N, 1, res_size);
                     let mut small_output = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 8 * N * res_size], N, 1, res_size);
                     let bracket = (a_size * a_base2k + res_size * res_base2k + 128) as i64;
-                    for offset in [-bracket, -(a_base2k as i64) - 1, -1, 0, 1, a_base2k as i64, bracket] {
+                    let gap = (a_size * a_base2k) as i64 - (res_size * res_base2k) as i64;
+                    for offset in [
+                        -bracket,
+                        -(a_base2k as i64) - 1,
+                        -1,
+                        0,
+                        1,
+                        a_base2k as i64,
+                        bracket,
+                        gap - a_base2k as i64 - 1,
+                        gap - a_base2k as i64,
+                        gap - 1,
+                    ] {
                         ntt4x30_vec_znx_big_normalize::<_, _, NTT4x30Ref>(
                             &mut output,
                             res_base2k,
@@ -693,7 +705,7 @@ fn test_vec_znx_big_normalize_wide_radices() {
                         .copy_from_slice(&[-NORMALIZE_IDFT_BOUND, NORMALIZE_IDFT_BOUND]);
                 }
                 let mut output = VecZnx::<Vec<u8>, i64>::from_data(vec![0; 16 * size], 2, 1, size);
-                for offset in [-400, -64, -1, 0, 1, 64, 400] {
+                for offset in [-400, -64, -(a_base2k as i64), -1, 0, 1, 64, 400] {
                     ntt4x30_vec_znx_big_normalize::<_, _, NTT4x30Ref>(
                         &mut output,
                         res_base2k,

--- a/poulpy-hal/src/api/vec_znx.rs
+++ b/poulpy-hal/src/api/vec_znx.rs
@@ -42,6 +42,7 @@ pub trait VecZnxExtractCoeffBackend<B: Backend> {
     );
 }
 
+/// Coefficient form of [`VecZnxNormalize`], with the same input and radix bounds.
 pub trait VecZnxNormalizeCoeffBackend<B: Backend> {
     #[allow(clippy::too_many_arguments)]
     /// Normalizes the selected coefficient of `a` across its limbs into a 1-coeff destination column.
@@ -71,6 +72,12 @@ pub trait VecZnxHadamardProductScalarZnxBackend<B: Backend> {
     );
 }
 
+/// Converts a column to centered digits, rounding once at the destination precision.
+///
+/// For i64 backends, each input limb coefficient must lie in `[-2^62, 2^62]`,
+/// and both radix widths must lie in `1..=62`. These bounds leave room for
+/// shifted digits and propagated carries. They are caller preconditions;
+/// normalization does not scan the input to validate them.
 pub trait VecZnxNormalize<B: Backend> {
     #[allow(clippy::too_many_arguments)]
     /// Normalizes the selected column of `a` and stores the result into the selected column of `res`.
@@ -87,6 +94,7 @@ pub trait VecZnxNormalize<B: Backend> {
     );
 }
 
+/// In-place normalization with the input and radix bounds of [`VecZnxNormalize`].
 pub trait VecZnxNormalizeAssignBackend<B: Backend> {
     fn vec_znx_normalize_assign_backend(
         &self,
@@ -97,6 +105,7 @@ pub trait VecZnxNormalizeAssignBackend<B: Backend> {
     );
 }
 
+/// In-place coefficient normalization with the bounds of [`VecZnxNormalize`].
 pub trait VecZnxNormalizeCoeffAssignBackend<B: Backend> {
     fn vec_znx_normalize_coeff_assign_backend(
         &self,

--- a/poulpy-hal/src/api/vec_znx_big.rs
+++ b/poulpy-hal/src/api/vec_znx_big.rs
@@ -274,6 +274,13 @@ pub trait VecZnxBigNormalizeTmpBytes {
 #[allow(clippy::too_many_arguments)]
 /// Normalizes a [`VecZnxBig`](crate::layouts::VecZnxBig) into a coefficient-domain
 /// [`VecZnx`](crate::layouts::VecZnx) with the target base and offset.
+///
+/// For i64 big words, the input and radix bounds of [`super::VecZnxNormalize`]
+/// apply. For i128 big words, input coefficients must lie in `[-2^126, 2^126]`,
+/// with input radix width in `1..=127` and output radix width in `1..=64`.
+/// NTT4x30 IDFT coefficients have the tighter bound `abs(a) < 2^119`.
+/// Additions before normalization must preserve the applicable coefficient
+/// bound. These are caller preconditions and are not checked by an input scan.
 pub trait VecZnxBigNormalize<B: Backend> {
     fn vec_znx_big_normalize(
         &self,

--- a/poulpy-hal/src/reference/znx/arithmetic_ref.rs
+++ b/poulpy-hal/src/reference/znx/arithmetic_ref.rs
@@ -208,8 +208,25 @@ impl ZnxNormalizeMiddleStepAssign for ZnxRef {
 
 impl ZnxExtractDigitAddMul for ZnxRef {
     #[inline(always)]
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+        super::znx_extract_digit_mul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         znx_extract_digit_addmul_ref(base2k, lsh, res, src);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        super::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
     }
 }
 

--- a/poulpy-hal/src/reference/znx/arithmetic_ref.rs
+++ b/poulpy-hal/src/reference/znx/arithmetic_ref.rs
@@ -208,25 +208,8 @@ impl ZnxNormalizeMiddleStepAssign for ZnxRef {
 
 impl ZnxExtractDigitAddMul for ZnxRef {
     #[inline(always)]
-    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-        super::znx_extract_digit_mul_ref(base2k, lsh, res, src);
-    }
-
-    #[inline(always)]
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         znx_extract_digit_addmul_ref(base2k, lsh, res, src);
-    }
-
-    #[inline(always)]
-    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i64],
-        carry: &mut [i64],
-    ) {
-        super::znx_extract_digit_addmul_normalize_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
     }
 }
 

--- a/poulpy-hal/src/reference/znx/mod.rs
+++ b/poulpy-hal/src/reference/znx/mod.rs
@@ -149,25 +149,10 @@ pub trait ZnxNormalizeFinalStepAssign {
 /// Extracts a centered digit and adds it shifted by `lsh` to the destination.
 /// Requires `1 <= base2k`, `base2k + lsh <= 62`, a representable destination
 /// sum, and `src - get_digit_i64(base2k, src)` representable in i64.
-/// Panics before writing if `src` or the supplied carry is shorter than `res`.
+/// Panics before writing if `src` is shorter than `res`.
 /// Entries beyond `res.len()` are unchanged.
 pub trait ZnxExtractDigitAddMul {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]);
-
-    /// Extracts a shifted digit into `res`, replacing its previous contents.
-    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]);
-
-    /// Extracts and adds a digit, then centers `res + carry` in the output base.
-    /// Requires `1 <= res_base2k <= 62`, both accumulated sums to fit in i64,
-    /// and their centered subtraction to fit in i64.
-    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i64],
-        carry: &mut [i64],
-    );
 }
 
 /// Centers the destination and adds its quotient to `src`.
@@ -175,29 +160,4 @@ pub trait ZnxExtractDigitAddMul {
 /// in i64, and the updated `src` coefficient to fit in i64.
 pub trait ZnxNormalizeDigit {
     fn znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]);
-}
-
-/// Extract a wide source digit and normalize the completed destination limb.
-/// Source coefficients and incoming carries must lie in `[-2^126, 2^126]`.
-/// Requires positive radix widths, `base2k + lsh <= 63`, `res_base2k <= 63`,
-/// and a representable i64 destination sum.
-/// Panics before writing if `src` or the supplied carry is shorter than `res`.
-/// Entries beyond `res.len()` are unchanged.
-pub trait ZnxExtractDigitAddMulI128 {
-    const FUSE_NORMALIZE: bool = true;
-
-    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-        znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
-    }
-
-    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
-        base2k: usize,
-        lsh: usize,
-        res_base2k: usize,
-        res: &mut [i64],
-        src: &mut [i128],
-        carry: &mut [i128],
-    ) {
-        znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
-    }
 }

--- a/poulpy-hal/src/reference/znx/mod.rs
+++ b/poulpy-hal/src/reference/znx/mod.rs
@@ -149,6 +149,8 @@ pub trait ZnxNormalizeFinalStepAssign {
 /// Extracts a centered digit and adds it shifted by `lsh` to the destination.
 /// Requires `1 <= base2k`, `base2k + lsh <= 62`, a representable destination
 /// sum, and `src - get_digit_i64(base2k, src)` representable in i64.
+/// Panics before writing if `src` or the supplied carry is shorter than `res`.
+/// Entries beyond `res.len()` are unchanged.
 pub trait ZnxExtractDigitAddMul {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]);
 
@@ -179,6 +181,8 @@ pub trait ZnxNormalizeDigit {
 /// Source coefficients and incoming carries must lie in `[-2^126, 2^126]`.
 /// Requires positive radix widths, `base2k + lsh <= 63`, `res_base2k <= 63`,
 /// and a representable i64 destination sum.
+/// Panics before writing if `src` or the supplied carry is shorter than `res`.
+/// Entries beyond `res.len()` are unchanged.
 pub trait ZnxExtractDigitAddMulI128 {
     const FUSE_NORMALIZE: bool = true;
 

--- a/poulpy-hal/src/reference/znx/mod.rs
+++ b/poulpy-hal/src/reference/znx/mod.rs
@@ -92,50 +92,108 @@ pub trait ZnxSwitchRing {
     fn znx_switch_ring(res: &mut [i64], a: &[i64]);
 }
 
+/// Starts centered normalization of i64 coefficients in `[-2^62, 2^62]`.
+/// Requires `1 <= base2k <= 62`, `lsh < base2k`, and representable destination
+/// sums when `OVERWRITE` is false.
 pub trait ZnxNormalizeFirstStep {
     fn znx_normalize_first_step<const OVERWRITE: bool>(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]);
 }
 
+/// Uses the input and radix bounds of [`ZnxNormalizeFirstStep`].
+/// Incoming carries must lie in `[-2^62, 2^62]`; the output carry stays there.
+/// These bounds keep the shifted digit sum and centered subtraction in i64.
 pub trait ZnxNormalizeMiddleStep {
     fn znx_normalize_middle_step<const OVERWRITE: bool>(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]);
 }
 
+/// Uses the bounds of [`ZnxNormalizeMiddleStep`] and discards the final carry.
 pub trait ZnxNormalizeFinalStep {
     fn znx_normalize_final_step<const OVERWRITE: bool>(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]);
 }
 
+/// Uses the input and radix bounds of [`ZnxNormalizeFirstStep`].
 pub trait ZnxNormalizeFirstStepCarryOnly {
     fn znx_normalize_first_step_carry_only(base2k: usize, lsh: usize, x: &[i64], carry: &mut [i64]);
 }
 
+/// In-place form with the input and radix bounds of [`ZnxNormalizeFirstStep`].
 pub trait ZnxNormalizeFirstStepAssign {
     fn znx_normalize_first_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64]);
 }
 
+/// Uses the carry bound of [`ZnxNormalizeMiddleStep`].
 pub trait ZnxNormalizeMiddleStepCarryOnly {
     fn znx_normalize_middle_step_carry_only(base2k: usize, lsh: usize, x: &[i64], carry: &mut [i64]);
 }
 
+/// Uses the carry bound of [`ZnxNormalizeMiddleStep`].
 pub trait ZnxNormalizeMiddleStepAssign {
     fn znx_normalize_middle_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64]);
 }
 
+/// Uses the carry bound of [`ZnxNormalizeMiddleStep`].
 pub trait ZnxNormalizeMiddleStepSub {
     fn znx_normalize_middle_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]);
 }
 
+/// Uses the bounds of [`ZnxNormalizeMiddleStep`] and requires representable destination differences.
 pub trait ZnxNormalizeFinalStepSub {
     fn znx_normalize_final_step_sub(base2k: usize, lsh: usize, x: &mut [i64], a: &[i64], carry: &mut [i64]);
 }
 
+/// In-place form with the bounds of [`ZnxNormalizeMiddleStep`].
 pub trait ZnxNormalizeFinalStepAssign {
     fn znx_normalize_final_step_assign(base2k: usize, lsh: usize, x: &mut [i64], carry: &mut [i64]);
 }
 
+/// Extracts a centered digit and adds it shifted by `lsh` to the destination.
+/// Requires `1 <= base2k`, `base2k + lsh <= 62`, a representable destination
+/// sum, and `src - get_digit_i64(base2k, src)` representable in i64.
 pub trait ZnxExtractDigitAddMul {
     fn znx_extract_digit_addmul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]);
+
+    /// Extracts a shifted digit into `res`, replacing its previous contents.
+    fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]);
+
+    /// Extracts and adds a digit, then centers `res + carry` in the output base.
+    /// Requires `1 <= res_base2k <= 62`, both accumulated sums to fit in i64,
+    /// and their centered subtraction to fit in i64.
+    fn znx_extract_digit_addmul_normalize<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i64],
+        carry: &mut [i64],
+    );
 }
 
+/// Centers the destination and adds its quotient to `src`.
+/// Requires `1 <= base2k <= 62`, the centered subtraction from `res` to fit
+/// in i64, and the updated `src` coefficient to fit in i64.
 pub trait ZnxNormalizeDigit {
     fn znx_normalize_digit(base2k: usize, res: &mut [i64], src: &mut [i64]);
+}
+
+/// Extract a wide source digit and normalize the completed destination limb.
+/// Source coefficients and incoming carries must lie in `[-2^126, 2^126]`.
+/// Requires positive radix widths, `base2k + lsh <= 63`, `res_base2k <= 63`,
+/// and a representable i64 destination sum.
+pub trait ZnxExtractDigitAddMulI128 {
+    const FUSE_NORMALIZE: bool = true;
+
+    fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+    }
+
+    fn znx_extract_digit_addmul_normalize_i128<const OVERWRITE: bool>(
+        base2k: usize,
+        lsh: usize,
+        res_base2k: usize,
+        res: &mut [i64],
+        src: &mut [i128],
+        carry: &mut [i128],
+    ) {
+        znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(base2k, lsh, res_base2k, res, src, carry);
+    }
 }

--- a/poulpy-hal/src/reference/znx/normalization.rs
+++ b/poulpy-hal/src/reference/znx/normalization.rs
@@ -162,6 +162,7 @@ pub fn znx_normalize_middle_step_assign_ref(base2k: usize, lsh: usize, x: &mut [
 
 #[inline(always)]
 pub fn znx_extract_digit_addmul_impl_ref<const OVERWRITE: bool>(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    assert!(src.len() >= res.len());
     for (r, s) in res.iter_mut().zip(src.iter_mut()) {
         let digit: i64 = get_digit_i64(base2k, *s);
         *s = get_carry_i64(base2k, *s, digit);
@@ -188,6 +189,8 @@ pub fn znx_extract_digit_addmul_normalize_ref<const OVERWRITE: bool>(
     src: &mut [i64],
     carry: &mut [i64],
 ) {
+    assert!(src.len() >= res.len());
+    assert!(carry.len() >= res.len());
     for ((r, s), c) in res.iter_mut().zip(src.iter_mut()).zip(carry.iter_mut()) {
         let digit = get_digit_i64(base2k, *s);
         *s = get_carry_i64(base2k, *s, digit);
@@ -364,6 +367,8 @@ pub fn znx_extract_digit_addmul_normalize_i128_ref<const OVERWRITE: bool>(
     src: &mut [i128],
     carry: &mut [i128],
 ) {
+    assert!(src.len() >= res.len());
+    assert!(carry.len() >= res.len());
     for ((r, s), c) in res.iter_mut().zip(src).zip(carry) {
         let digit = get_digit_i128(base2k, *s);
         *s = get_carry_i128(base2k, *s, digit);
@@ -380,6 +385,7 @@ pub fn znx_extract_digit_addmul_normalize_i128_ref<const OVERWRITE: bool>(
 
 /// Extract a wide source digit and initialize a destination limb.
 pub fn znx_extract_digit_mul_i128_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+    assert!(src.len() >= res.len());
     for (r, s) in res.iter_mut().zip(src) {
         let digit = get_digit_i128(base2k, *s);
         *s = get_carry_i128(base2k, *s, digit);

--- a/poulpy-hal/src/reference/znx/normalization.rs
+++ b/poulpy-hal/src/reference/znx/normalization.rs
@@ -161,43 +161,12 @@ pub fn znx_normalize_middle_step_assign_ref(base2k: usize, lsh: usize, x: &mut [
 }
 
 #[inline(always)]
-pub fn znx_extract_digit_addmul_impl_ref<const OVERWRITE: bool>(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+pub fn znx_extract_digit_addmul_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
     assert!(src.len() >= res.len());
     for (r, s) in res.iter_mut().zip(src.iter_mut()) {
-        let digit: i64 = get_digit_i64(base2k, *s);
-        *s = get_carry_i64(base2k, *s, digit);
-        *r = if OVERWRITE { digit << lsh } else { *r + (digit << lsh) };
-    }
-}
-
-#[inline(always)]
-pub fn znx_extract_digit_addmul_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-    znx_extract_digit_addmul_impl_ref::<false>(base2k, lsh, res, src);
-}
-
-#[inline(always)]
-pub fn znx_extract_digit_mul_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
-    znx_extract_digit_addmul_impl_ref::<true>(base2k, lsh, res, src);
-}
-
-#[inline(always)]
-pub fn znx_extract_digit_addmul_normalize_ref<const OVERWRITE: bool>(
-    base2k: usize,
-    lsh: usize,
-    res_base2k: usize,
-    res: &mut [i64],
-    src: &mut [i64],
-    carry: &mut [i64],
-) {
-    assert!(src.len() >= res.len());
-    assert!(carry.len() >= res.len());
-    for ((r, s), c) in res.iter_mut().zip(src.iter_mut()).zip(carry.iter_mut()) {
         let digit = get_digit_i64(base2k, *s);
         *s = get_carry_i64(base2k, *s, digit);
-        let partial = if OVERWRITE { digit << lsh } else { *r + (digit << lsh) };
-        let sum = partial + *c;
-        *r = get_digit_i64(res_base2k, sum);
-        *c = get_carry_i64(res_base2k, sum, *r);
+        *r += digit << lsh;
     }
 }
 
@@ -355,41 +324,6 @@ pub fn znx_normalize_final_step_sub_ref(base2k: usize, lsh: usize, x: &mut [i64]
         izip!(x.iter_mut(), a.iter(), carry.iter_mut()).for_each(|(x, a, c)| {
             *x -= get_digit_i64(base2k, (get_digit_i64(base2k_lsh, *a) << lsh) + *c);
         });
-    }
-}
-
-/// Fused wide extraction and destination carry normalization.
-pub fn znx_extract_digit_addmul_normalize_i128_ref<const OVERWRITE: bool>(
-    base2k: usize,
-    lsh: usize,
-    res_base2k: usize,
-    res: &mut [i64],
-    src: &mut [i128],
-    carry: &mut [i128],
-) {
-    assert!(src.len() >= res.len());
-    assert!(carry.len() >= res.len());
-    for ((r, s), c) in res.iter_mut().zip(src).zip(carry) {
-        let digit = get_digit_i128(base2k, *s);
-        *s = get_carry_i128(base2k, *s, digit);
-        let previous = if OVERWRITE { 0i64 } else { *r };
-        let accum = previous.wrapping_add((digit as i64).wrapping_shl(lsh as u32)) as i128;
-        let d = get_digit_i128(res_base2k, accum);
-        let q = get_carry_i128(res_base2k, accum, d);
-        let sum = d + *c;
-        let out = get_digit_i128(res_base2k, sum);
-        *r = out as i64;
-        *c = q + get_carry_i128(res_base2k, sum, out);
-    }
-}
-
-/// Extract a wide source digit and initialize a destination limb.
-pub fn znx_extract_digit_mul_i128_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
-    assert!(src.len() >= res.len());
-    for (r, s) in res.iter_mut().zip(src) {
-        let digit = get_digit_i128(base2k, *s);
-        *s = get_carry_i128(base2k, *s, digit);
-        *r = (digit as i64).wrapping_shl(lsh as u32);
     }
 }
 

--- a/poulpy-hal/src/reference/znx/normalization.rs
+++ b/poulpy-hal/src/reference/znx/normalization.rs
@@ -5,6 +5,8 @@ pub fn get_digit_i64(base2k: usize, x: i64) -> i64 {
     (x << (u64::BITS - base2k as u32)) >> (u64::BITS - base2k as u32)
 }
 
+/// Requires `digit == get_digit_i64(base2k, x)` and a representable mathematical `x - digit`.
+/// Sufficient bounds are `|x| <= 2^62` and `1 <= base2k <= 62`.
 #[inline(always)]
 pub fn get_carry_i64(base2k: usize, x: i64, digit: i64) -> i64 {
     (x.wrapping_sub(digit)) >> base2k
@@ -15,6 +17,8 @@ pub fn get_digit_i128(base2k: usize, x: i128) -> i128 {
     (x << (u128::BITS - base2k as u32)) >> (u128::BITS - base2k as u32)
 }
 
+/// Requires `digit == get_digit_i128(base2k, x)` and a representable mathematical `x - digit`.
+/// Sufficient bounds are `|x| <= 2^126` and `1 <= base2k <= 126`.
 #[inline(always)]
 pub fn get_carry_i128(base2k: usize, x: i128, digit: i128) -> i128 {
     (x.wrapping_sub(digit)) >> base2k
@@ -157,11 +161,40 @@ pub fn znx_normalize_middle_step_assign_ref(base2k: usize, lsh: usize, x: &mut [
 }
 
 #[inline(always)]
-pub fn znx_extract_digit_addmul_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+pub fn znx_extract_digit_addmul_impl_ref<const OVERWRITE: bool>(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
     for (r, s) in res.iter_mut().zip(src.iter_mut()) {
         let digit: i64 = get_digit_i64(base2k, *s);
         *s = get_carry_i64(base2k, *s, digit);
-        *r += digit << lsh;
+        *r = if OVERWRITE { digit << lsh } else { *r + (digit << lsh) };
+    }
+}
+
+#[inline(always)]
+pub fn znx_extract_digit_addmul_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    znx_extract_digit_addmul_impl_ref::<false>(base2k, lsh, res, src);
+}
+
+#[inline(always)]
+pub fn znx_extract_digit_mul_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
+    znx_extract_digit_addmul_impl_ref::<true>(base2k, lsh, res, src);
+}
+
+#[inline(always)]
+pub fn znx_extract_digit_addmul_normalize_ref<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i64],
+    carry: &mut [i64],
+) {
+    for ((r, s), c) in res.iter_mut().zip(src.iter_mut()).zip(carry.iter_mut()) {
+        let digit = get_digit_i64(base2k, *s);
+        *s = get_carry_i64(base2k, *s, digit);
+        let partial = if OVERWRITE { digit << lsh } else { *r + (digit << lsh) };
+        let sum = partial + *c;
+        *r = get_digit_i64(res_base2k, sum);
+        *c = get_carry_i64(res_base2k, sum, *r);
     }
 }
 
@@ -319,5 +352,75 @@ pub fn znx_normalize_final_step_sub_ref(base2k: usize, lsh: usize, x: &mut [i64]
         izip!(x.iter_mut(), a.iter(), carry.iter_mut()).for_each(|(x, a, c)| {
             *x -= get_digit_i64(base2k, (get_digit_i64(base2k_lsh, *a) << lsh) + *c);
         });
+    }
+}
+
+/// Fused wide extraction and destination carry normalization.
+pub fn znx_extract_digit_addmul_normalize_i128_ref<const OVERWRITE: bool>(
+    base2k: usize,
+    lsh: usize,
+    res_base2k: usize,
+    res: &mut [i64],
+    src: &mut [i128],
+    carry: &mut [i128],
+) {
+    for ((r, s), c) in res.iter_mut().zip(src).zip(carry) {
+        let digit = get_digit_i128(base2k, *s);
+        *s = get_carry_i128(base2k, *s, digit);
+        let previous = if OVERWRITE { 0i64 } else { *r };
+        let accum = previous.wrapping_add((digit as i64).wrapping_shl(lsh as u32)) as i128;
+        let d = get_digit_i128(res_base2k, accum);
+        let q = get_carry_i128(res_base2k, accum, d);
+        let sum = d + *c;
+        let out = get_digit_i128(res_base2k, sum);
+        *r = out as i64;
+        *c = q + get_carry_i128(res_base2k, sum, out);
+    }
+}
+
+/// Extract a wide source digit and initialize a destination limb.
+pub fn znx_extract_digit_mul_i128_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+    for (r, s) in res.iter_mut().zip(src) {
+        let digit = get_digit_i128(base2k, *s);
+        *s = get_carry_i128(base2k, *s, digit);
+        *r = (digit as i64).wrapping_shl(lsh as u32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_centered_digit_bounded_word() {
+        let mut state = 0xa631_77da_ce94_3201u128;
+        let bound = 1i128 << 126;
+        for k in 1..=126 {
+            let half = 1i128 << (k - 1);
+            let edges = [-bound, bound, -half, half, -half - 1, half - 1, -1, 0, 1];
+            for i in 0..1033 {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                let x = if i < edges.len() { edges[i] } else { (state as i128) >> 1 };
+                let digit = get_digit_i128(k, x);
+                let carry = get_carry_i128(k, x, digit);
+                let base = 1i128 << k;
+                let expected = x.div_euclid(base) + i128::from(x.rem_euclid(base) >= half);
+                assert!((-half..half).contains(&digit));
+                assert_eq!(carry, expected, "i128 k={k}, x={x}");
+                assert_eq!(carry * base + digit, x);
+                if k <= 62 {
+                    let bound = 1i64 << 62;
+                    let half = half as i64;
+                    let edges = [-bound, bound, -half, half, -half - 1, half - 1, -1, 0, 1];
+                    let x = if i < edges.len() { edges[i] } else { (state as i64) >> 1 };
+                    let digit = get_digit_i64(k, x);
+                    let carry = get_carry_i64(k, x, digit);
+                    assert_eq!(x as i128, digit as i128 + (carry as i128) * base);
+                    assert!((-half..half).contains(&digit));
+                }
+            }
+        }
     }
 }

--- a/poulpy-hal/src/test_suite/mod.rs
+++ b/poulpy-hal/src/test_suite/mod.rs
@@ -12,6 +12,7 @@ use crate::layouts::{
 };
 
 pub mod convolution;
+pub mod normalization;
 pub mod serialization;
 pub mod svp;
 pub mod vec_znx;
@@ -204,3 +205,4 @@ macro_rules! cross_backend_test_suite {
         }
     };
 }
+pub mod normalization_i128;

--- a/poulpy-hal/src/test_suite/mod.rs
+++ b/poulpy-hal/src/test_suite/mod.rs
@@ -12,7 +12,6 @@ use crate::layouts::{
 };
 
 pub mod convolution;
-pub mod normalization;
 pub mod serialization;
 pub mod svp;
 pub mod vec_znx;
@@ -205,4 +204,3 @@ macro_rules! cross_backend_test_suite {
         }
     };
 }
-pub mod normalization_i128;

--- a/poulpy-hal/src/test_suite/normalization.rs
+++ b/poulpy-hal/src/test_suite/normalization.rs
@@ -1,0 +1,177 @@
+//! Bounded coefficient tests shared by the normalization backends.
+
+use crate::reference::znx::*;
+
+type Step = fn(usize, usize, &mut [i64], &[i64], &mut [i64]);
+type AssignStep = fn(usize, usize, &mut [i64], &mut [i64]);
+
+/// Compare every normalization kernel, including scalar tails, for every base and shift.
+pub fn test_normalization_kernels<B>()
+where
+    B: ZnxNormalizeFirstStep
+        + ZnxNormalizeMiddleStep
+        + ZnxNormalizeFinalStep
+        + ZnxNormalizeFirstStepCarryOnly
+        + ZnxNormalizeFirstStepAssign
+        + ZnxNormalizeMiddleStepCarryOnly
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxNormalizeMiddleStepSub
+        + ZnxNormalizeFinalStepSub
+        + ZnxNormalizeFinalStepAssign
+        + ZnxExtractDigitAddMul
+        + ZnxNormalizeDigit,
+{
+    let steps: [(Step, Step); 8] = [
+        (znx_normalize_first_step_ref::<true>, B::znx_normalize_first_step::<true>),
+        (znx_normalize_first_step_ref::<false>, B::znx_normalize_first_step::<false>),
+        (znx_normalize_middle_step_ref::<true>, B::znx_normalize_middle_step::<true>),
+        (znx_normalize_middle_step_ref::<false>, B::znx_normalize_middle_step::<false>),
+        (znx_normalize_middle_step_sub_ref, B::znx_normalize_middle_step_sub),
+        (znx_normalize_final_step_ref::<true>, B::znx_normalize_final_step::<true>),
+        (znx_normalize_final_step_ref::<false>, B::znx_normalize_final_step::<false>),
+        (znx_normalize_final_step_sub_ref, B::znx_normalize_final_step_sub),
+    ];
+    let assign_steps: [(AssignStep, AssignStep); 3] = [
+        (znx_normalize_first_step_assign_ref, B::znx_normalize_first_step_assign),
+        (znx_normalize_middle_step_assign_ref, B::znx_normalize_middle_step_assign),
+        (znx_normalize_final_step_assign_ref, B::znx_normalize_final_step_assign),
+    ];
+    let mut state = 0xc105_ca77_1234_5678u64;
+    for k in 1..=62 {
+        let half = 1i64 << (k - 1);
+        let edge = [
+            -(1i64 << 62),
+            1i64 << 62,
+            -half,
+            half,
+            -half - 1,
+            half - 1,
+            -half + 1,
+            half + 1,
+            -1,
+            0,
+            1,
+        ];
+        for lsh in 0..k {
+            let shifted_half = 1i64 << (k - lsh - 1);
+            let mut edge = edge.to_vec();
+            edge.extend([
+                -shifted_half,
+                shifted_half,
+                -shifted_half - 1,
+                shifted_half - 1,
+                -shifted_half + 1,
+                shifted_half + 1,
+            ]);
+            for n in [0, 1, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33] {
+                let a: Vec<_> = (0..n)
+                    .map(|i| {
+                        state ^= state << 13;
+                        state ^= state >> 7;
+                        state ^= state << 17;
+                        if i < edge.len() {
+                            edge[(i + lsh) % edge.len()]
+                        } else {
+                            state as i64 >> 1
+                        }
+                    })
+                    .collect();
+                let mut carry = vec![0; n + 3];
+                znx_normalize_first_step_carry_only_ref(k, lsh, &a, &mut carry);
+                carry[..n].rotate_left(n / 2);
+                for (c, endpoint) in carry[..n].iter_mut().zip([-(1i64 << 62), 1i64 << 62]) {
+                    *c = endpoint;
+                }
+                for (index, (reference, backend)) in steps.iter().enumerate() {
+                    let mut r = vec![7; n];
+                    let mut b = r.clone();
+                    let mut rc = carry.clone();
+                    let mut bc = carry.clone();
+                    reference(k, lsh, &mut r, &a, &mut rc);
+                    backend(k, lsh, &mut b, &a, &mut bc);
+                    assert_eq!((&r, &rc), (&b, &bc), "step={index}, k={k}, lsh={lsh}, n={n}");
+                    let base = 1i128 << k;
+                    for i in 0..n {
+                        let total = ((a[i] as i128) << lsh) + if index < 2 { 0 } else { carry[i] as i128 };
+                        let q = (total + base / 2).div_euclid(base);
+                        let d = (total - q * base) as i64;
+                        let expected = match index {
+                            0 | 2 | 5 => d,
+                            4 | 7 => 7 - d,
+                            _ => 7 + d,
+                        };
+                        assert_eq!(r[i], expected, "oracle step={index}, k={k}, lsh={lsh}");
+                        assert_eq!(rc[i], if index < 5 { q as i64 } else { carry[i] });
+                    }
+                }
+                for (reference, backend) in &assign_steps {
+                    let mut r = a.clone();
+                    let mut b = a.clone();
+                    let mut rc = carry.clone();
+                    let mut bc = carry.clone();
+                    reference(k, lsh, &mut r, &mut rc);
+                    backend(k, lsh, &mut b, &mut bc);
+                    assert_eq!((&r, &rc), (&b, &bc), "assign k={k}, lsh={lsh}, n={n}");
+                }
+                for first in [true, false] {
+                    let mut rc = carry.clone();
+                    let mut bc = carry.clone();
+                    if first {
+                        znx_normalize_first_step_carry_only_ref(k, lsh, &a, &mut rc);
+                        B::znx_normalize_first_step_carry_only(k, lsh, &a, &mut bc);
+                    } else {
+                        znx_normalize_middle_step_carry_only_ref(k, lsh, &a, &mut rc);
+                        B::znx_normalize_middle_step_carry_only(k, lsh, &a, &mut bc);
+                    }
+                    assert_eq!(rc, bc, "carry only k={k}, lsh={lsh}, n={n}");
+                }
+                let mut r = vec![0; n];
+                let mut b = r.clone();
+                let mut rs = a.clone();
+                let mut bs = a.clone();
+                znx_extract_digit_addmul_ref(k - lsh, lsh, &mut r, &mut rs);
+                B::znx_extract_digit_addmul(k - lsh, lsh, &mut b, &mut bs);
+                assert_eq!((&r, &rs), (&b, &bs), "extract k={k}, lsh={lsh}, n={n}");
+                r.fill(0);
+                b.fill(1i64 << 62);
+                rs.copy_from_slice(&a);
+                bs.copy_from_slice(&a);
+                znx_extract_digit_addmul_ref(k - lsh, lsh, &mut r, &mut rs);
+                B::znx_extract_digit_mul(k - lsh, lsh, &mut b, &mut bs);
+                assert_eq!((&r, &rs), (&b, &bs), "extract overwrite k={k}, lsh={lsh}, n={n}");
+                for overwrite in [false, true] {
+                    for (i, value) in r.iter_mut().enumerate() {
+                        *value = if overwrite || k == 1 { 0 } else { get_digit_i64(k - 1, a[i]) };
+                    }
+                    b.copy_from_slice(&r);
+                    if overwrite {
+                        b.fill(1i64 << 62);
+                    }
+                    rs.copy_from_slice(&a);
+                    bs.copy_from_slice(&a);
+                    let mut rc: Vec<_> = (0..n + 3).map(|i| (i % 3) as i64 - 1).collect();
+                    let mut bc = rc.clone();
+                    znx_extract_digit_addmul_ref(k - lsh, lsh, &mut r, &mut rs);
+                    znx_normalize_middle_step_assign_ref(k, 0, &mut r, &mut rc);
+                    if overwrite {
+                        B::znx_extract_digit_addmul_normalize::<true>(k - lsh, lsh, k, &mut b, &mut bs, &mut bc);
+                    } else {
+                        B::znx_extract_digit_addmul_normalize::<false>(k - lsh, lsh, k, &mut b, &mut bs, &mut bc);
+                    }
+                    assert_eq!(
+                        (&r, &rs, &rc),
+                        (&b, &bs, &bc),
+                        "fused overwrite={overwrite}, k={k}, lsh={lsh}, n={n}"
+                    );
+                }
+                r.copy_from_slice(&a);
+                b.copy_from_slice(&a);
+                rs.fill(0);
+                bs.fill(0);
+                znx_normalize_digit_ref(k, &mut r, &mut rs);
+                B::znx_normalize_digit(k, &mut b, &mut bs);
+                assert_eq!((&r, &rs), (&b, &bs), "digit k={k}, lsh={lsh}, n={n}");
+            }
+        }
+    }
+}

--- a/poulpy-hal/src/test_suite/normalization_i128.rs
+++ b/poulpy-hal/src/test_suite/normalization_i128.rs
@@ -1,0 +1,85 @@
+//! Wide fused normalization parity across backend implementations.
+
+use crate::reference::znx::{ZnxExtractDigitAddMulI128, get_digit_i64, znx_extract_digit_addmul_normalize_i128_ref};
+
+pub fn test_i128_normalize_fused<BE: ZnxExtractDigitAddMulI128>() {
+    let idft_bound = (1_073_479_681i128 * 1_071_513_601 * 1_070_727_169 * 1_068_236_801 - 1) / 2;
+    for res_base2k in 1..=63 {
+        for base2k in 1..=res_base2k {
+            let half = 1i128 << (base2k - 1);
+            let mut input = vec![
+                -(1i128 << 126),
+                1i128 << 126,
+                -idft_bound,
+                idft_bound,
+                -half - 1,
+                -half,
+                half - 1,
+                half,
+                -1,
+                0,
+                1,
+            ];
+            let mut state = 0x123456789abcdef0u128;
+            for _ in 0..12 {
+                state ^= state << 17;
+                state ^= state >> 29;
+                state ^= state << 43;
+                input.push(state as i128 >> 1);
+            }
+            let mut res: Vec<_> = input
+                .iter()
+                .map(|&v| {
+                    if res_base2k == 1 {
+                        0
+                    } else {
+                        get_digit_i64(res_base2k - 1, v as i64)
+                    }
+                })
+                .collect();
+            let mut carry: Vec<_> = (0..input.len()).map(|i| -(i as i128 & 1)).collect();
+            let original_input = input.clone();
+            let original_res = res.clone();
+            let original_carry = carry.clone();
+            let mut want_input = input.clone();
+            let mut want_res = res.clone();
+            let mut want_carry = carry.clone();
+            let scale = res_base2k - base2k;
+            znx_extract_digit_addmul_normalize_i128_ref::<false>(
+                base2k,
+                scale,
+                res_base2k,
+                &mut want_res,
+                &mut want_input,
+                &mut want_carry,
+            );
+            BE::znx_extract_digit_addmul_normalize_i128::<false>(base2k, scale, res_base2k, &mut res, &mut input, &mut carry);
+            assert_eq!(
+                (&res, &input, &carry),
+                (&want_res, &want_input, &want_carry),
+                "take={base2k} res_base2k={res_base2k}"
+            );
+            input.clone_from(&original_input);
+            want_input.clone_from(&original_input);
+            carry.clone_from(&original_carry);
+            want_carry.clone_from(&original_carry);
+            res.clone_from(&original_res);
+            want_res.clone_from(&original_res);
+            znx_extract_digit_addmul_normalize_i128_ref::<true>(
+                base2k,
+                scale,
+                res_base2k,
+                &mut want_res,
+                &mut want_input,
+                &mut want_carry,
+            );
+            BE::znx_extract_digit_addmul_normalize_i128::<true>(base2k, scale, res_base2k, &mut res, &mut input, &mut carry);
+            assert_eq!((&res, &input, &carry), (&want_res, &want_input, &want_carry));
+            input.clone_from(&original_input);
+            want_input.clone_from(&original_input);
+            crate::reference::znx::znx_extract_digit_mul_i128_ref(base2k, scale, &mut want_res, &mut want_input);
+            BE::znx_extract_digit_mul_i128(base2k, scale, &mut res, &mut input);
+            assert_eq!((&res, &input), (&want_res, &want_input));
+        }
+    }
+}


### PR DESCRIPTION
- **new:** CPU-only overwrite and fused extraction hooks with scalar defaults (`I64NormalizeOps` is required when reusing the shared CPU loops), exact integer-oracle tests (595,210 boundary cases across usual and extreme base widths by default; the full 285,149,916-case sweep is ignored), SIMD parity coverage, and cross-base Criterion benchmarks (`--bench normalize`).
- **changed:** Fix [#256](https://github.com/poulpy-fhe/poulpy/issues/256) (cross-base limb ranges), same-base and cross-base truncation rounding and offsets, and wide add/sub normalization; validate extraction slice lengths before writing; reduce memory passes, block serial i64 cross-base calls, and retain vector kernels when same-base truncation drops at most one limb.
- **removed:** Duplicated wide assignment loops, obsolete helpers and redundant output zeroing.
- **others:** Keep HAL backend agnostic: CPU fusion policy, kernels and parity tests live in `poulpy-cpu-ref`; document input bounds, add test-only `dashu-int`, and restore NEON Rayon VMP forwarding.
- **defered:** Native AVX-512/IFMA/NEON validation and further reduction of cross-base normalization overhead.

## Correctness fixes

- **[#256](https://github.com/poulpy-fhe/poulpy/issues/256), cross-base output limbs outside the normalized range:** combining signed sub-digits could leave their sum outside `[-2^(res_base2k-1), 2^(res_base2k-1))`, even when it represented the correct value. For example, an accumulated `-9` at `res_base2k=4` must become digit `7` with carry `-1` into the next more significant limb. The fix centers every completed output limb and propagates its carry before advancing, including partial final limbs and limb 0 before returning; carry beyond limb 0 is discarded modulo one. CPU implementations can perform this centering in the last extraction pass. This covers shared vector/coefficient loops and the wide NTT4x30 copies.

- **Incorrect rounding when dropping precision:** the old loops could round discarded limbs successively and return the wrong nearest value. With `a_base2k=res_base2k=2`, input `[0,1,2]` represents `3/32`; reducing it to one output limb at offset 0 incorrectly returned `[1]` (`1/4`) instead of `[0]`. The exact bit reader now handles cross-base truncation and same-base truncation dropping more than one limb, propagating carries exactly and rounding once at the destination precision, with ties toward positive infinity. Same-base calls dropping at most one limb keep the existing kernels because they already perform only one rounding step. Integer-oracle regressions check the value independently; limb-bound tests separately check the normalized range.

- **Short source or carry slices could cause out-of-bounds SIMD access:** narrow and wide extraction now validate lengths before any writes on reference, AVX2, AVX-512, IFMA and NEON backends, including Rayon forwarding.

## Performance

Against **original `origin/main` (`9361627e`)**, the recorded 4,800-case bounded-input sweep (before the slice-length guards and CPU/HAL separation) takes **49.2% more time** geometrically: **+1.8% same-base2k**, **+64.2% cross-base2k**. Big normalization separately:

| Backend | Same-base2k time change | Cross-base2k time change |
|---|---:|---:|
| FFT64 reference | +1.5% | +98.0% |
| FFT64 AVX2 | +2.2% | +87.6% |
| NTT4x30 reference | +1.3% | +15.4% |
| NTT4x30 AVX2 | +5.7% | +7.1% |

## Added lines by purpose

| Area | Added | Removed | Purpose |
|---|---:|---:|---|
| Shared CPU normalization and scalar kernels | 572 | 334 | Exact rounding, limb scheduling, carry propagation, scalar extraction, CPU hooks and coefficient blocking. |
| SIMD kernels | 496 | 51 | Overwrite and fused extraction, wide arithmetic fixes and scalar fallbacks. |
| Traits and backend integration | 519 | 30 | CPU hook implementations and forwarding across reference, SIMD and Rayon backends; HAL contracts stay backend agnostic. |
| Tests | 1,520 | 130 | Integer oracle, exhaustive cases, regressions, CPU kernel parity and coefficient/range checks. |
| Benchmarks | 198 | 18 | Parameter sweep, bounded inputs and the Criterion benchmark target. |
| Documentation | 42 | 0 | Benchmark instructions, API contracts and CHANGELOG. |
| Build configuration | 5 | 1 | Test oracle dependency, lockfile entries and manifest formatting. |
| Other compatibility fix | 16 | 0 | Restore NEON Rayon VMP selected-row forwarding. |
| **Total** | **3,368** | **564** | **Net increase: 2,804 lines.** |
