### PR TITLE
Improve normalization performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@
 ### `poulpy-hal`
 
 - **Breaking:** normalization now takes the target precision `k` and produces its canonical representation.
+- Round normalization once at the requested precision within its existing traversal, removing the separate canonicalization pass and per-coefficient i128 remainder operations.
 - Reject short source and carry slices before extraction kernels write, including the AVX2, AVX-512, IFMA and NEON implementations.
 - **Breaking:** uniform `VecZnx` sampling now takes the target precision `k`; the sampler masks the unused low bits of the last live limb and clears limbs above `k`.
 - The cross-backend `test_vmp_apply_dft_to_dft_accumulate` now sweeps `res` sizes that differ from the prepared matrix size and non-zero `limb_offset`, so the output limb window is compared across transform families.
+
+### `poulpy-bin-fhe`
+
+- Decrypt `FheUint` at its two-bit encoding precision so normalization preserves noisy bit values.
 
 ### `poulpy-core`
 
@@ -27,6 +32,10 @@ Adds opt-in intra-operation Rayon scheduling to every accelerated CPU arithmetic
 
 ### CPU backends
 
+- Accelerate normalization floor carries, precision-boundary rounding and wide carry propagation with native AVX2, AVX-512/IFMA and NEON kernels, including Rayon delegation.
+- Check source and carry lengths before wide normalization kernels access memory.
+- Extend normalization kernel parity tests and benchmark sweeps to full, partial and multi-limb truncated precision across every CPU family.
+- Retain slice kernels for cross-base precision truncation and use i64 scratch for normalized NTT digits without changing public scratch sizes. The CPU `I128NormalizeOps` trait now also requires `I64NormalizeOps` and `ZnxNormalizeMiddleStepAssign`.
 - Document normalization input headroom and fix single-round precision truncation, extreme offsets, and overflowing wide add/sub normalization.
 - Reduce normalization zeroing, specialize exact bit arithmetic by source width, block serial i64 cross-base calls, and retain vector kernels for same-base truncation of at most one limb without changing scratch reservations.
 - Add bounded exact integer normalization tests, centered boundary cases across usual and extreme base widths (full enumeration of bases 1 through 6 via `--ignored`), and cross-base Criterion sweeps via `cargo bench --bench normalize` in `poulpy-cpu-avx`.

--- a/poulpy-bench/src/hal/params.rs
+++ b/poulpy-bench/src/hal/params.rs
@@ -156,14 +156,15 @@ pub struct NormalizeSweepParams {
     pub a_base2k: usize,
     pub res_base2k: usize,
     pub res_offset: i64,
+    pub drop_bits: usize,
 }
 
 impl Display for NormalizeSweepParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}/k={}->{}/offset={}",
-            self.shape, self.a_base2k, self.res_base2k, self.res_offset
+            "{}/k={}->{}/offset={}/drop={}",
+            self.shape, self.a_base2k, self.res_base2k, self.res_offset, self.drop_bits
         )
     }
 }
@@ -175,12 +176,15 @@ pub fn default_bench_params_normalize() -> Vec<NormalizeSweepParams> {
             for a_base2k in [17, 19, 21, 50, 51] {
                 for res_base2k in [17, 19, 21, 50, 51] {
                     for res_offset in [-(a_base2k as i64), 0, 1, a_base2k as i64] {
-                        result.push(NormalizeSweepParams {
-                            shape: HalSweepParms { n, cols: 1, size },
-                            a_base2k,
-                            res_base2k,
-                            res_offset,
-                        });
+                        for drop_bits in [0, res_base2k / 2, 2 * res_base2k + 1] {
+                            result.push(NormalizeSweepParams {
+                                shape: HalSweepParms { n, cols: 1, size },
+                                a_base2k,
+                                res_base2k,
+                                res_offset,
+                                drop_bits,
+                            });
+                        }
                     }
                 }
             }

--- a/poulpy-bench/src/hal/vec_znx/normalize.rs
+++ b/poulpy-bench/src/hal/vec_znx/normalize.rs
@@ -27,6 +27,7 @@ where
             a_base2k: 50,
             res_base2k: 50,
             res_offset: 0,
+            drop_bits: 0,
         },
     );
 }
@@ -57,7 +58,7 @@ pub fn runner_vec_znx_normalize_sweep<B: Backend<ZnxWord = i64>, M: Measurement>
             module.vec_znx_normalize(
                 &mut res,
                 params.res_base2k,
-                sweep.size * params.res_base2k,
+                sweep.size * params.res_base2k - params.drop_bits,
                 params.res_offset,
                 i,
                 &a,

--- a/poulpy-bench/src/hal/vec_znx_big.rs
+++ b/poulpy-bench/src/hal/vec_znx_big.rs
@@ -228,6 +228,7 @@ pub fn runner_vec_znx_big_normalize<B: Backend<ZnxWord = i64>, M: Measurement>(
             a_base2k: 50,
             res_base2k: 50,
             res_offset: 0,
+            drop_bits: 0,
         },
     );
 }
@@ -258,7 +259,7 @@ pub fn runner_vec_znx_big_normalize_sweep<B: Backend<ZnxWord = i64>, M: Measurem
             module.vec_znx_big_normalize(
                 &mut res,
                 params.res_base2k,
-                sweep.size * params.res_base2k,
+                sweep.size * params.res_base2k - params.drop_bits,
                 params.res_offset,
                 i,
                 &a,

--- a/poulpy-bin-fhe/src/bdd_arithmetic/ciphertexts/fhe_uint.rs
+++ b/poulpy-bin-fhe/src/bdd_arithmetic/ciphertexts/fhe_uint.rs
@@ -244,7 +244,7 @@ impl<D: HostDataRef, T: UnsignedInteger + FromBits> FheUint<D, T, i64> {
         let pt_infos = GLWEPlaintextLayout {
             n: self.n(),
             base2k: self.base2k(),
-            k: 1_usize.into(),
+            k: 2_usize.into(),
         };
 
         // TODO(device): this decrypt helper still stages the plaintext in a
@@ -276,7 +276,7 @@ impl<D: HostDataRef, T: UnsignedInteger + FromBits> FheUint<D, T, i64> {
         let pt_infos = GLWEPlaintextLayout {
             n: self.n(),
             base2k: self.base2k(),
-            k: 1_usize.into(),
+            k: 2_usize.into(),
         };
         module.glwe_plaintext_bytes_of_from_infos(&pt_infos) + module.glwe_decrypt_tmp_bytes(self)
     }

--- a/poulpy-cpu-arm/Cargo.toml
+++ b/poulpy-cpu-arm/Cargo.toml
@@ -63,3 +63,8 @@ required-features = ["enable-neon", "enable-ckks"]
 name = "light"
 harness = false
 required-features = ["enable-neon", "enable-ckks"]
+
+[[bench]]
+name = "normalize"
+harness = false
+required-features = ["enable-neon"]

--- a/poulpy-cpu-arm/benches/normalize.rs
+++ b/poulpy-cpu-arm/benches/normalize.rs
@@ -1,0 +1,19 @@
+//! Same-base and cross-base normalization at full and partial precision.
+use criterion::{criterion_group, criterion_main};
+use poulpy_bench::hal::suites::bench_normalization;
+use poulpy_cpu_arm::{FFT64Neon, NTT4x30Neon};
+
+fn parallel(_c: &mut criterion::Criterion) {
+    #[cfg(feature = "enable-rayon")]
+    {
+        bench_normalization::<poulpy_cpu_arm::FFT64NeonRayon>(_c);
+        bench_normalization::<poulpy_cpu_arm::NTT4x30NeonRayon>(_c);
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = poulpy_bench::criterion_config();
+    targets = bench_normalization::<FFT64Neon>, bench_normalization::<NTT4x30Neon>, parallel
+}
+criterion_main!(benches);

--- a/poulpy-cpu-arm/src/fft64/znx.rs
+++ b/poulpy-cpu-arm/src/fft64/znx.rs
@@ -242,6 +242,37 @@ impl ZnxExtractDigitAddMul for FFT64Neon {
 }
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for FFT64Neon {
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        crate::neon::normalization_boundary::znx_normalize_floor_neon::<CARRY_IN, ROUND>(base2k, lsh, a, carry);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        crate::neon::normalization_boundary::znx_normalize_round_neon::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        crate::neon::normalization_boundary::znx_normalize_round_assign_neon::<CARRY_IN>(base2k, lsh, padding, res, carry);
+    }
+
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         #[cfg(target_arch = "aarch64")]

--- a/poulpy-cpu-arm/src/neon/mod.rs
+++ b/poulpy-cpu-arm/src/neon/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod conv_i64;
 pub(crate) mod fft;
+pub(crate) mod normalization_boundary;
 pub(crate) mod normalize;
 pub(crate) mod ntt4x30_arithmetic;
 pub(crate) mod ntt4x30_convert;

--- a/poulpy-cpu-arm/src/neon/normalization_boundary.rs
+++ b/poulpy-cpu-arm/src/neon/normalization_boundary.rs
@@ -1,0 +1,235 @@
+//! NEON floor carry propagation and rounding at a precision boundary.
+
+use core::arch::aarch64::{
+    int64x2_t, uint64x2_t, vaddq_s64, vaddq_u64, vandq_u64, vdupq_n_s64, vdupq_n_u64, vld1q_s64, vorrq_u64,
+    vreinterpretq_s64_u64, vreinterpretq_u64_s64, vshlq_s64, vshlq_u64, vst1q_s64,
+};
+use poulpy_cpu_ref::reference::normalization::{
+    nfc_normalize_floor_ref, nfc_normalize_round_ref, znx_normalize_floor_ref, znx_normalize_round_assign_ref,
+    znx_normalize_round_ref,
+};
+
+use super::vec_znx_big::{add2_i128, load2_i128, store2_i128};
+
+struct Boundary {
+    mask: uint64x2_t,
+    source_mask: uint64x2_t,
+    source_right: int64x2_t,
+    source_left: int64x2_t,
+    base_right: int64x2_t,
+    base_left: int64x2_t,
+    lsh: int64x2_t,
+    guard_right: int64x2_t,
+    padding_left: int64x2_t,
+    padding_right: int64x2_t,
+    half: uint64x2_t,
+    center_half: uint64x2_t,
+    center_right: int64x2_t,
+    digit_left: int64x2_t,
+    digit_right: int64x2_t,
+}
+
+impl Boundary {
+    #[inline(always)]
+    fn new(base2k: usize, lsh: usize, padding: usize) -> Self {
+        assert!((1..=63).contains(&base2k));
+        assert!(lsh < base2k && padding < base2k);
+        let source_bits = base2k - lsh;
+        let width = base2k - padding;
+        unsafe {
+            Self {
+                mask: vdupq_n_u64((1u64 << base2k) - 1),
+                source_mask: vdupq_n_u64((1u64 << source_bits) - 1),
+                source_right: vdupq_n_s64(-(source_bits as i64)),
+                source_left: vdupq_n_s64((64 - source_bits) as i64),
+                base_right: vdupq_n_s64(-(base2k as i64)),
+                base_left: vdupq_n_s64((64 - base2k) as i64),
+                lsh: vdupq_n_s64(lsh as i64),
+                guard_right: vdupq_n_s64(1 - base2k as i64),
+                padding_left: vdupq_n_s64(padding as i64),
+                padding_right: vdupq_n_s64(-(padding as i64)),
+                half: vdupq_n_u64(if padding == 0 { 0 } else { 1u64 << (padding - 1) }),
+                center_half: vdupq_n_u64(1u64 << (width - 1)),
+                center_right: vdupq_n_s64(-(width as i64)),
+                digit_left: vdupq_n_s64((64 - width) as i64),
+                digit_right: vdupq_n_s64(-((64 - width) as i64)),
+            }
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn floor_i64<const CARRY_IN: bool>(&self, a: int64x2_t, carry: int64x2_t) -> (uint64x2_t, int64x2_t) {
+        unsafe {
+            let mut low = vshlq_u64(vandq_u64(vreinterpretq_u64_s64(a), self.source_mask), self.lsh);
+            let mut high = vshlq_s64(a, self.source_right);
+            if CARRY_IN {
+                low = vaddq_u64(low, vandq_u64(vreinterpretq_u64_s64(carry), self.mask));
+                high = vaddq_s64(high, vshlq_s64(carry, self.base_right));
+                high = vaddq_s64(high, vreinterpretq_s64_u64(vshlq_u64(low, self.base_right)));
+            }
+            (vandq_u64(low, self.mask), high)
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn floor_i128<const CARRY_IN: bool>(
+        &self,
+        a: (uint64x2_t, int64x2_t),
+        carry: (uint64x2_t, int64x2_t),
+    ) -> (uint64x2_t, (uint64x2_t, int64x2_t)) {
+        unsafe {
+            let mut low = vshlq_u64(vandq_u64(a.0, self.source_mask), self.lsh);
+            let mut high = shift_i128(a, self.source_right, self.source_left);
+            if CARRY_IN {
+                low = vaddq_u64(low, vandq_u64(carry.0, self.mask));
+                let c_high = shift_i128(carry, self.base_right, self.base_left);
+                high = add2_i128(high.0, high.1, c_high.0, c_high.1);
+                high = add2_i128(high.0, high.1, vshlq_u64(low, self.base_right), vdupq_n_s64(0));
+            }
+            (vandq_u64(low, self.mask), high)
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn round<const PAD: bool>(&self, low: uint64x2_t) -> (int64x2_t, uint64x2_t) {
+        unsafe {
+            let rounded = vshlq_u64(vaddq_u64(low, self.half), self.padding_right);
+            let carry = vshlq_u64(vaddq_u64(rounded, self.center_half), self.center_right);
+            let digit = vshlq_s64(vshlq_s64(vreinterpretq_s64_u64(rounded), self.digit_left), self.digit_right);
+            (if PAD { vshlq_s64(digit, self.padding_left) } else { digit }, carry)
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn shift_i128(a: (uint64x2_t, int64x2_t), right: int64x2_t, left: int64x2_t) -> (uint64x2_t, int64x2_t) {
+    unsafe {
+        (
+            vorrq_u64(vshlq_u64(a.0, right), vshlq_u64(vreinterpretq_u64_s64(a.1), left)),
+            vshlq_s64(a.1, right),
+        )
+    }
+}
+
+#[inline]
+pub(crate) fn znx_normalize_floor_neon<const CARRY_IN: bool, const ROUND: bool>(
+    base2k: usize,
+    lsh: usize,
+    a: &[i64],
+    carry: &mut [i64],
+) {
+    assert!(a.len() >= carry.len());
+    let boundary = Boundary::new(base2k, lsh, 0);
+    let tail = carry.len() & !1;
+    unsafe {
+        let zero = vdupq_n_s64(0);
+        for i in (0..tail).step_by(2) {
+            let incoming = if CARRY_IN { vld1q_s64(carry.as_ptr().add(i)) } else { zero };
+            let (low, mut high) = boundary.floor_i64::<CARRY_IN>(vld1q_s64(a.as_ptr().add(i)), incoming);
+            if ROUND {
+                high = vaddq_s64(high, vreinterpretq_s64_u64(vshlq_u64(low, boundary.guard_right)));
+            }
+            vst1q_s64(carry.as_mut_ptr().add(i), high);
+        }
+    }
+    znx_normalize_floor_ref::<CARRY_IN, ROUND>(base2k, lsh, &a[tail..], &mut carry[tail..]);
+}
+
+#[inline]
+pub(crate) fn znx_normalize_round_neon<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i64],
+    carry: &mut [i64],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    let boundary = Boundary::new(base2k, lsh, padding);
+    let tail = res.len() & !1;
+    unsafe {
+        let zero = vdupq_n_s64(0);
+        for i in (0..tail).step_by(2) {
+            let incoming = if CARRY_IN { vld1q_s64(carry.as_ptr().add(i)) } else { zero };
+            let (low, high) = boundary.floor_i64::<CARRY_IN>(vld1q_s64(a.as_ptr().add(i)), incoming);
+            let (digit, next) = boundary.round::<PAD>(low);
+            vst1q_s64(res.as_mut_ptr().add(i), digit);
+            vst1q_s64(carry.as_mut_ptr().add(i), vaddq_s64(high, vreinterpretq_s64_u64(next)));
+        }
+    }
+    znx_normalize_round_ref::<CARRY_IN, PAD>(base2k, lsh, padding, &mut res[tail..], &a[tail..], &mut carry[tail..]);
+}
+
+#[inline]
+pub(crate) fn znx_normalize_round_assign_neon<const CARRY_IN: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    carry: &mut [i64],
+) {
+    assert!(carry.len() >= res.len());
+    let boundary = Boundary::new(base2k, lsh, padding);
+    let tail = res.len() & !1;
+    unsafe {
+        let zero = vdupq_n_s64(0);
+        for i in (0..tail).step_by(2) {
+            let incoming = if CARRY_IN { vld1q_s64(carry.as_ptr().add(i)) } else { zero };
+            let (low, high) = boundary.floor_i64::<CARRY_IN>(vld1q_s64(res.as_ptr().add(i)), incoming);
+            let (digit, next) = boundary.round::<true>(low);
+            vst1q_s64(res.as_mut_ptr().add(i), digit);
+            vst1q_s64(carry.as_mut_ptr().add(i), vaddq_s64(high, vreinterpretq_s64_u64(next)));
+        }
+    }
+    znx_normalize_round_assign_ref::<CARRY_IN>(base2k, lsh, padding, &mut res[tail..], &mut carry[tail..]);
+}
+
+#[inline]
+pub(crate) fn nfc_normalize_floor_neon<const CARRY_IN: bool, const ROUND: bool>(
+    base2k: usize,
+    lsh: usize,
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= carry.len());
+    let boundary = Boundary::new(base2k, lsh, 0);
+    let tail = carry.len() & !1;
+    unsafe {
+        let zero = (vdupq_n_u64(0), vdupq_n_s64(0));
+        for i in (0..tail).step_by(2) {
+            let incoming = if CARRY_IN { load2_i128(carry.as_ptr().add(i)) } else { zero };
+            let (low, mut high) = boundary.floor_i128::<CARRY_IN>(load2_i128(a.as_ptr().add(i)), incoming);
+            if ROUND {
+                high = add2_i128(high.0, high.1, vshlq_u64(low, boundary.guard_right), zero.1);
+            }
+            store2_i128(carry.as_mut_ptr().add(i), high.0, high.1);
+        }
+    }
+    nfc_normalize_floor_ref::<CARRY_IN, ROUND>(base2k, lsh, &a[tail..], &mut carry[tail..]);
+}
+
+#[inline]
+pub(crate) fn nfc_normalize_round_neon<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    let boundary = Boundary::new(base2k, lsh, padding);
+    let tail = res.len() & !1;
+    unsafe {
+        let zero = (vdupq_n_u64(0), vdupq_n_s64(0));
+        for i in (0..tail).step_by(2) {
+            let incoming = if CARRY_IN { load2_i128(carry.as_ptr().add(i)) } else { zero };
+            let (low, high) = boundary.floor_i128::<CARRY_IN>(load2_i128(a.as_ptr().add(i)), incoming);
+            let (digit, next) = boundary.round::<PAD>(low);
+            let high = add2_i128(high.0, high.1, next, zero.1);
+            vst1q_s64(res.as_mut_ptr().add(i), digit);
+            store2_i128(carry.as_mut_ptr().add(i), high.0, high.1);
+        }
+    }
+    nfc_normalize_round_ref::<CARRY_IN, PAD>(base2k, lsh, padding, &mut res[tail..], &a[tail..], &mut carry[tail..]);
+}

--- a/poulpy-cpu-arm/src/neon/normalize.rs
+++ b/poulpy-cpu-arm/src/neon/normalize.rs
@@ -186,6 +186,7 @@ unsafe fn nfc_final_chunk(s: &NfcShifts, lo_a: int64x2_t, lo_c: int64x2_t) -> in
 /// `base2k > 64`. Caller must satisfy `lsh < base2k`.
 #[inline]
 pub(crate) fn nfc_middle_step_neon(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
     if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step(base2k, lsh, res, a, carry);
         return;
@@ -217,6 +218,7 @@ pub(crate) fn nfc_middle_step_neon(base2k: usize, lsh: usize, res: &mut [i64], a
 /// `nfc_middle_step_into` — fused middle step for `res ±= normalize(a)`.
 #[inline]
 pub(crate) fn nfc_middle_step_into_neon<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
     if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step_into::<O>(base2k, lsh, res, a, carry);
         return;
@@ -261,6 +263,7 @@ pub(crate) fn nfc_middle_step_into_neon<O: AssignOp>(base2k: usize, lsh: usize, 
 /// `nfc_middle_step_assign` — in-place `i64` `res` update with `i128` carry.
 #[inline]
 pub(crate) fn nfc_middle_step_assign_neon(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+    assert!(carry.len() >= res.len());
     if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_middle_step_assign(base2k, lsh, res, carry);
         return;
@@ -290,6 +293,7 @@ pub(crate) fn nfc_middle_step_assign_neon(base2k: usize, lsh: usize, res: &mut [
 /// `nfc_final_step_assign` — flush i128 carry into the last i64 limb.
 #[inline]
 pub(crate) fn nfc_final_step_assign_neon(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+    assert!(carry.len() >= res.len());
     if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_final_step_assign(base2k, lsh, res, carry);
         return;
@@ -321,6 +325,7 @@ pub(crate) fn nfc_final_step_assign_neon(base2k: usize, lsh: usize, res: &mut [i
 /// `nfc_final_step_into` — fused final step for `res ±= normalize(a)`.
 #[inline]
 pub(crate) fn nfc_final_step_into_neon<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+    assert!(carry.len() >= res.len());
     if base2k >= 64 || res.len() < 2 {
         <NTT4x30Ref as I128NormalizeOps>::nfc_final_step_into::<O>(base2k, lsh, res, carry);
         return;
@@ -367,8 +372,10 @@ pub(crate) unsafe fn nfc_extract_normalize_neon<const OVERWRITE: bool, const FIN
             poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k, lsh, res_base2k, res, src, carry,
             );
-        } else {
+        } else if OVERWRITE {
             poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+        } else {
+            <NTT4x30Ref as I128NormalizeOps>::znx_extract_digit_addmul_i128(base2k, lsh, res, src);
         }
         return;
     }
@@ -403,8 +410,10 @@ pub(crate) unsafe fn nfc_extract_normalize_neon<const OVERWRITE: bool, const FIN
                 &mut src[end..],
                 &mut carry[end..],
             );
-        } else {
+        } else if OVERWRITE {
             poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+        } else {
+            <NTT4x30Ref as I128NormalizeOps>::znx_extract_digit_addmul_i128(base2k, lsh, &mut res[end..], &mut src[end..]);
         }
     }
 }

--- a/poulpy-cpu-arm/src/neon/vec_znx_big.rs
+++ b/poulpy-cpu-arm/src/neon/vec_znx_big.rs
@@ -6,7 +6,7 @@ use core::arch::aarch64::{
 };
 
 #[inline(always)]
-unsafe fn load2_i128(p: *const i128) -> (uint64x2_t, int64x2_t) {
+pub(super) unsafe fn load2_i128(p: *const i128) -> (uint64x2_t, int64x2_t) {
     unsafe {
         let v0: int64x2_t = vld1q_s64(p as *const i64); // [lo0, hi0]
         let v1: int64x2_t = vld1q_s64((p as *const i64).add(2)); // [lo1, hi1]
@@ -37,7 +37,7 @@ unsafe fn vshrq_helper_arith_63(v: int64x2_t) -> int64x2_t {
 }
 
 #[inline(always)]
-unsafe fn store2_i128(p: *mut i128, lo: uint64x2_t, hi: int64x2_t) {
+pub(super) unsafe fn store2_i128(p: *mut i128, lo: uint64x2_t, hi: int64x2_t) {
     unsafe {
         let lo_s: int64x2_t = vreinterpretq_s64_u64(lo);
         let v0: int64x2_t = vzip1q_s64(lo_s, hi); // [lo0, hi0]
@@ -49,7 +49,7 @@ unsafe fn store2_i128(p: *mut i128, lo: uint64x2_t, hi: int64x2_t) {
 
 /// `(lo_r, hi_r) = (lo_a, hi_a) + (lo_b, hi_b)` over 2 lanes of i128.
 #[inline(always)]
-unsafe fn add2_i128(lo_a: uint64x2_t, hi_a: int64x2_t, lo_b: uint64x2_t, hi_b: int64x2_t) -> (uint64x2_t, int64x2_t) {
+pub(super) unsafe fn add2_i128(lo_a: uint64x2_t, hi_a: int64x2_t, lo_b: uint64x2_t, hi_b: int64x2_t) -> (uint64x2_t, int64x2_t) {
     unsafe {
         let lo_r: uint64x2_t = vaddq_u64(lo_a, lo_b);
         // carry mask: lanes where lo_r < lo_a (unsigned overflow) = -1.

--- a/poulpy-cpu-arm/src/ntt4x30/rayon.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/rayon.rs
@@ -210,6 +210,40 @@ impl ZnxExtractDigitAddMul for NTT4x30NeonRayon {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30NeonRayon {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        <NTT4x30Neon as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_floor::<CARRY_IN, ROUND>(
+            base2k, lsh, a, carry,
+        );
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        <NTT4x30Neon as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round::<CARRY_IN, PAD>(
+            base2k, lsh, padding, res, a, carry,
+        );
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <NTT4x30Neon as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round_assign::<CARRY_IN>(
+            base2k, lsh, padding, res, carry,
+        );
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT4x30Neon as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }
@@ -374,6 +408,33 @@ impl I128BigOps for NTT4x30NeonRayon {
 }
 
 impl I128NormalizeOps for NTT4x30NeonRayon {
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        <NTT4x30Neon as I128NormalizeOps>::nfc_normalize_floor::<CARRY_IN, ROUND>(base2k, lsh, a, carry);
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Neon as I128NormalizeOps>::nfc_normalize_round::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry);
+    }
+
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        <NTT4x30Neon as I128NormalizeOps>::nfc_add_small_carry(carry, a);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Neon as I128NormalizeOps>::znx_extract_digit_addmul_i128(base2k, lsh, res, src);
+    }
+
     const FUSE_NORMALIZE: bool = <NTT4x30Neon as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
 
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {

--- a/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/vec_znx_big.rs
@@ -94,6 +94,37 @@ impl poulpy_cpu_ref::hal_defaults::BigWordHadamardProduct for NTT4x30Neon {
 
 #[cfg(target_arch = "aarch64")]
 impl I128NormalizeOps for NTT4x30Neon {
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        crate::neon::normalization_boundary::nfc_normalize_floor_neon::<CARRY_IN, ROUND>(base2k, lsh, a, carry);
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        crate::neon::normalization_boundary::nfc_normalize_round_neon::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry);
+    }
+
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        assert!(a.len() >= carry.len());
+        vi128_add_small_assign_neon(carry.len(), carry, a);
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe {
+            crate::neon::normalize::nfc_extract_normalize_neon::<false, false>(base2k, lsh, base2k + lsh, res, src, &mut []);
+        }
+    }
+
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
         assert!(src.len() >= res.len());
         unsafe { crate::neon::normalize::nfc_extract_normalize_neon::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }

--- a/poulpy-cpu-arm/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/znx.rs
@@ -242,6 +242,37 @@ impl ZnxExtractDigitAddMul for NTT4x30Neon {
 }
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Neon {
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        crate::neon::normalization_boundary::znx_normalize_floor_neon::<CARRY_IN, ROUND>(base2k, lsh, a, carry);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        crate::neon::normalization_boundary::znx_normalize_round_neon::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        crate::neon::normalization_boundary::znx_normalize_round_assign_neon::<CARRY_IN>(base2k, lsh, padding, res, carry);
+    }
+
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         #[cfg(target_arch = "aarch64")]

--- a/poulpy-cpu-avx/benches/normalize.rs
+++ b/poulpy-cpu-avx/benches/normalize.rs
@@ -5,6 +5,14 @@ use poulpy_bench::hal::suites::bench_normalization;
 use poulpy_cpu_avx::{FFT64Avx, NTT4x30Avx};
 use poulpy_cpu_ref::{FFT64Ref, NTT4x30Ref};
 
+fn parallel(_c: &mut criterion::Criterion) {
+    #[cfg(feature = "enable-rayon")]
+    {
+        bench_normalization::<poulpy_cpu_avx::FFT64AvxRayon>(_c);
+        bench_normalization::<poulpy_cpu_avx::NTT4x30AvxRayon>(_c);
+    }
+}
+
 criterion_group! {
     name = benches;
     config = poulpy_bench::criterion_config();
@@ -12,7 +20,8 @@ criterion_group! {
         bench_normalization::<FFT64Ref>,
         bench_normalization::<NTT4x30Ref>,
         bench_normalization::<FFT64Avx>,
-        bench_normalization::<NTT4x30Avx>
+        bench_normalization::<NTT4x30Avx>,
+        parallel
 }
 
 criterion_main!(benches);

--- a/poulpy-cpu-avx/src/fft64/module.rs
+++ b/poulpy-cpu-avx/src/fft64/module.rs
@@ -460,6 +460,37 @@ impl ZnxExtractDigitAddMul for FFT64Avx {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for FFT64Avx {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { crate::znx_avx::znx_normalize_floor_avx::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { crate::znx_avx::znx_normalize_round_avx::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        assert!(carry.len() >= res.len());
+        unsafe { crate::znx_avx::znx_normalize_round_assign_avx::<CARRY_IN>(base2k, lsh, padding, res, carry) }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx::znx_extract_digit_mul_avx(base2k, lsh, res, src);

--- a/poulpy-cpu-avx/src/ntt4x30/rayon.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/rayon.rs
@@ -229,6 +229,43 @@ impl ZnxExtractDigitAddMul for NTT4x30AvxRayon {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30AvxRayon {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        assert!(a.len() >= carry.len());
+        <NTT4x30Avx as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_floor::<CARRY_IN, ROUND>(
+            base2k, lsh, a, carry,
+        )
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        <NTT4x30Avx as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round::<CARRY_IN, PAD>(
+            base2k, lsh, padding, res, a, carry,
+        )
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        assert!(carry.len() >= res.len());
+        <NTT4x30Avx as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round_assign::<CARRY_IN>(
+            base2k, lsh, padding, res, carry,
+        )
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT4x30Avx as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }
@@ -393,6 +430,35 @@ impl I128BigOps for NTT4x30AvxRayon {
 }
 
 impl I128NormalizeOps for NTT4x30AvxRayon {
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        <NTT4x30Avx as I128NormalizeOps>::nfc_add_small_carry(carry, a)
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Avx as I128NormalizeOps>::znx_extract_digit_addmul_i128(base2k, lsh, res, src)
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= carry.len());
+        <NTT4x30Avx as I128NormalizeOps>::nfc_normalize_floor::<CARRY_IN, ROUND>(base2k, lsh, a, carry)
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        <NTT4x30Avx as I128NormalizeOps>::nfc_normalize_round::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry)
+    }
+
     const FUSE_NORMALIZE: bool = <NTT4x30Avx as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
 
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {

--- a/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/vec_znx_big.rs
@@ -93,6 +93,39 @@ impl BigWordHadamardProduct for NTT4x30Avx {
 }
 
 impl I128NormalizeOps for NTT4x30Avx {
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { vi128_add_small_assign_avx2(carry.len(), carry, a) }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe {
+            super::vec_znx_big_avx::nfc_extract_normalize_avx2::<false, false>(base2k, lsh, base2k + lsh, res, src, &mut [])
+        }
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= carry.len());
+        unsafe { super::vec_znx_big_avx::nfc_normalize_floor_avx2::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { super::vec_znx_big_avx::nfc_normalize_round_avx2::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
         assert!(src.len() >= res.len());
         unsafe { super::vec_znx_big_avx::nfc_extract_normalize_avx2::<true, false>(base2k, lsh, base2k + lsh, res, src, &mut []) }
@@ -113,6 +146,7 @@ impl I128NormalizeOps for NTT4x30Avx {
 
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
         // SAFETY: NTT4x30Avx::new() verifies AVX2 availability at construction time.
         if base2k <= 64 && res.len() >= 4 {
             unsafe { nfc_middle_step_avx2(base2k as u32, lsh as u32, res.len(), res, a, carry) }
@@ -123,6 +157,7 @@ impl I128NormalizeOps for NTT4x30Avx {
 
     #[inline(always)]
     fn nfc_middle_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         // SAFETY: NTT4x30Avx::new() verifies AVX2 availability at construction time.
         if base2k <= 64 && res.len() >= 4 {
             unsafe { nfc_middle_step_assign_avx2(base2k as u32, lsh as u32, res.len(), res, carry) }
@@ -133,6 +168,7 @@ impl I128NormalizeOps for NTT4x30Avx {
 
     #[inline(always)]
     fn nfc_final_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         // SAFETY: NTT4x30Avx::new() verifies AVX2 availability at construction time.
         if base2k <= 64 && res.len() >= 4 {
             unsafe { nfc_final_step_assign_avx2(base2k as u32, lsh as u32, res.len(), res, carry) }

--- a/poulpy-cpu-avx/src/ntt4x30/vec_znx_big_avx.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/vec_znx_big_avx.rs
@@ -30,6 +30,119 @@ use std::arch::x86_64::*;
 use itertools::izip;
 use poulpy_cpu_ref::reference::znx::{get_carry_i128, get_digit_i128};
 
+/// Floor-decompose four shifted i128 values without a signed left shift.
+#[inline(always)]
+unsafe fn nfc_floor_chunk<const CARRY_IN: bool>(
+    shifts: &NfcShifts,
+    boundary: &crate::znx_avx::NormalizationBoundaryAvx,
+    source: (__m256i, __m256i),
+    carry: (__m256i, __m256i),
+) -> (__m256i, __m256i, __m256i) {
+    unsafe {
+        let (low, overflow) = boundary.floor_low::<CARRY_IN>(source.0, carry.0);
+        let source_lo = _mm256_or_si256(
+            _mm256_srl_epi64(source.0, shifts.srl_b2klsh),
+            _mm256_sll_epi64(source.1, shifts.sll_b2klsh),
+        );
+        let source_hi = sra_epi64(source.1, shifts.b2klsh);
+        let (high_lo, high_hi) = if CARRY_IN {
+            let carry_lo = _mm256_or_si256(
+                _mm256_srl_epi64(carry.0, shifts.srl_b2k),
+                _mm256_sll_epi64(carry.1, shifts.sll_b2k),
+            );
+            let carry_hi = sra_epi64(carry.1, shifts.b2k);
+            add4_i128(source_lo, source_hi, carry_lo, carry_hi)
+        } else {
+            (source_lo, source_hi)
+        };
+        let (high_lo, high_hi) = add4_i128(high_lo, high_hi, overflow, shifts.zero);
+        (low, high_lo, high_hi)
+    }
+}
+
+/// # Safety
+/// Requires AVX2. Slice lengths and radix parameters are checked before access.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub(super) unsafe fn nfc_normalize_floor_avx2<const CARRY_IN: bool, const ROUND: bool>(
+    base2k: usize,
+    lsh: usize,
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= carry.len());
+    unsafe {
+        let boundary = crate::znx_avx::NormalizationBoundaryAvx::new(base2k, lsh, 0);
+        let shifts = NfcShifts::new(base2k as u32, lsh as u32);
+        let chunks = carry.len() / 4;
+        for i in 0..chunks {
+            let source = load4_i128(a.as_ptr().cast(), i);
+            let incoming = if CARRY_IN {
+                load4_i128(carry.as_ptr().cast(), i)
+            } else {
+                (shifts.zero, shifts.zero)
+            };
+            let (low, mut high_lo, mut high_hi) = nfc_floor_chunk::<CARRY_IN>(&shifts, &boundary, source, incoming);
+            if ROUND {
+                (high_lo, high_hi) = add4_i128(high_lo, high_hi, boundary.round_bit(low), shifts.zero);
+            }
+            store4_i128(carry.as_mut_ptr().cast(), i, high_lo, high_hi);
+        }
+        let end = chunks * 4;
+        poulpy_cpu_ref::reference::normalization::nfc_normalize_floor_ref::<CARRY_IN, ROUND>(
+            base2k,
+            lsh,
+            &a[end..],
+            &mut carry[end..],
+        );
+    }
+}
+
+/// # Safety
+/// Requires AVX2. Slice lengths and radix parameters are checked before access.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub(super) unsafe fn nfc_normalize_round_avx2<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    unsafe {
+        let boundary = crate::znx_avx::NormalizationBoundaryAvx::new(base2k, lsh, padding);
+        let shifts = NfcShifts::new(base2k as u32, lsh as u32);
+        let chunks = res.len() / 4;
+        for i in 0..chunks {
+            let source = load4_i128(a.as_ptr().cast(), i);
+            let incoming = if CARRY_IN {
+                load4_i128(carry.as_ptr().cast(), i)
+            } else {
+                (shifts.zero, shifts.zero)
+            };
+            let (low, high_lo, high_hi) = nfc_floor_chunk::<CARRY_IN>(&shifts, &boundary, source, incoming);
+            let (digit, extra) = boundary.round::<PAD>(low);
+            let (high_lo, high_hi) = add4_i128(high_lo, high_hi, extra, shifts.zero);
+            _mm256_storeu_si256(
+                res.as_mut_ptr().cast::<__m256i>().add(i),
+                _mm256_permute4x64_epi64(digit, 0xD8),
+            );
+            store4_i128(carry.as_mut_ptr().cast(), i, high_lo, high_hi);
+        }
+        let end = chunks * 4;
+        poulpy_cpu_ref::reference::normalization::nfc_normalize_round_ref::<CARRY_IN, PAD>(
+            base2k,
+            lsh,
+            padding,
+            &mut res[end..],
+            &a[end..],
+            &mut carry[end..],
+        );
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Scalar fallback helpers (used as tails in AVX2 kernels)
 // ──────────────────────────────────────────────────────────────────────────────
@@ -961,19 +1074,27 @@ pub(super) unsafe fn nfc_extract_normalize_avx2<const OVERWRITE: bool, const FIN
     src: &mut [i128],
     carry: &mut [i128],
 ) {
-    if base2k >= 64 || res_base2k >= 64 {
+    let extract_tail = |res: &mut [i64], src: &mut [i128]| {
+        for (out, source) in res.iter_mut().zip(src) {
+            let digit = get_digit_i128(base2k, *source);
+            let value = (digit as i64).wrapping_shl(lsh as u32);
+            *out = if OVERWRITE { value } else { out.wrapping_add(value) };
+            *source = get_carry_i128(base2k, *source, digit);
+        }
+    };
+    if base2k >= 64 || (FINALIZE && res_base2k >= 64) {
         if FINALIZE {
             poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k, lsh, res_base2k, res, src, carry,
             );
         } else {
-            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+            extract_tail(res, src);
         }
         return;
     }
     unsafe {
         let source_shifts = NfcShifts::new(base2k as u32, 0);
-        let result_shifts = NfcShifts::new(res_base2k as u32, 0);
+        let result_shifts = NfcShifts::new(if FINALIZE { res_base2k } else { base2k } as u32, 0);
         let scale = _mm_cvtsi64_si128(lsh as i64);
         let zero = _mm256_setzero_si256();
 
@@ -1019,7 +1140,7 @@ pub(super) unsafe fn nfc_extract_normalize_avx2<const OVERWRITE: bool, const FIN
                 &mut carry[end..],
             );
         } else {
-            poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+            extract_tail(&mut res[end..], &mut src[end..]);
         }
     }
 }

--- a/poulpy-cpu-avx/src/ntt4x30/znx.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/znx.rs
@@ -216,6 +216,37 @@ impl ZnxExtractDigitAddMul for NTT4x30Avx {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Avx {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { crate::znx_avx::znx_normalize_floor_avx::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { crate::znx_avx::znx_normalize_round_avx::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        assert!(carry.len() >= res.len());
+        unsafe { crate::znx_avx::znx_normalize_round_assign_avx::<CARRY_IN>(base2k, lsh, padding, res, carry) }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx::znx_extract_digit_mul_avx(base2k, lsh, res, src);

--- a/poulpy-cpu-avx/src/znx_avx/mod.rs
+++ b/poulpy-cpu-avx/src/znx_avx/mod.rs
@@ -4,6 +4,7 @@ mod automorphism_rotate;
 mod mul;
 mod neg;
 mod normalization;
+mod normalization_boundary;
 mod sub;
 mod switch_ring;
 
@@ -13,5 +14,6 @@ pub(crate) use automorphism_rotate::*;
 pub(crate) use mul::*;
 pub(crate) use neg::*;
 pub(crate) use normalization::*;
+pub(crate) use normalization_boundary::*;
 pub(crate) use sub::*;
 pub(crate) use switch_ring::*;

--- a/poulpy-cpu-avx/src/znx_avx/normalization_boundary.rs
+++ b/poulpy-cpu-avx/src/znx_avx/normalization_boundary.rs
@@ -1,0 +1,211 @@
+use std::arch::x86_64::*;
+
+/// Masks and shifts shared by the narrow and split-word rounding kernels.
+pub(crate) struct NormalizationBoundaryAvx {
+    mask: __m256i,
+    source_mask: __m256i,
+    sign: __m256i,
+    digit_mask: __m256i,
+    digit_sign: __m256i,
+    half: __m256i,
+    source_bias: __m256i,
+    carry_bias: __m256i,
+    source_shift: __m128i,
+    carry_shift: __m128i,
+    lsh: __m128i,
+    padding: __m128i,
+    width: __m128i,
+    round_shift: __m128i,
+}
+
+impl NormalizationBoundaryAvx {
+    #[inline(always)]
+    pub(crate) unsafe fn new(base2k: usize, lsh: usize, padding: usize) -> Self {
+        assert!((1..=63).contains(&base2k) && lsh < base2k && padding < base2k);
+        unsafe {
+            let source_bits = base2k - lsh;
+            let width = base2k - padding;
+            Self {
+                mask: _mm256_set1_epi64x(((1u64 << base2k) - 1) as i64),
+                source_mask: _mm256_set1_epi64x(((1u64 << source_bits) - 1) as i64),
+                sign: _mm256_set1_epi64x(i64::MIN),
+                digit_mask: _mm256_set1_epi64x(((1u64 << width) - 1) as i64),
+                digit_sign: _mm256_set1_epi64x((1u64 << (width - 1)) as i64),
+                half: _mm256_set1_epi64x(if padding == 0 { 0 } else { 1i64 << (padding - 1) }),
+                source_bias: _mm256_set1_epi64x((1u64 << (63 - source_bits)) as i64),
+                carry_bias: _mm256_set1_epi64x((1u64 << (63 - base2k)) as i64),
+                source_shift: _mm_cvtsi64_si128(source_bits as i64),
+                carry_shift: _mm_cvtsi64_si128(base2k as i64),
+                lsh: _mm_cvtsi64_si128(lsh as i64),
+                padding: _mm_cvtsi64_si128(padding as i64),
+                width: _mm_cvtsi64_si128(width as i64),
+                round_shift: _mm_cvtsi64_si128((base2k - 1) as i64),
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn floor_low<const CARRY_IN: bool>(&self, a: __m256i, carry: __m256i) -> (__m256i, __m256i) {
+        unsafe {
+            let low_a = _mm256_sll_epi64(_mm256_and_si256(a, self.source_mask), self.lsh);
+            let sum = if CARRY_IN {
+                _mm256_add_epi64(low_a, _mm256_and_si256(carry, self.mask))
+            } else {
+                low_a
+            };
+            (_mm256_and_si256(sum, self.mask), _mm256_srl_epi64(sum, self.carry_shift))
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn floor<const CARRY_IN: bool>(&self, a: __m256i, carry: __m256i) -> (__m256i, __m256i) {
+        unsafe {
+            let (low, overflow) = self.floor_low::<CARRY_IN>(a, carry);
+            // Biasing the sign bit turns a logical shift into signed floor division.
+            let source = _mm256_sub_epi64(
+                _mm256_srl_epi64(_mm256_xor_si256(a, self.sign), self.source_shift),
+                self.source_bias,
+            );
+            let high = if CARRY_IN {
+                let incoming = _mm256_sub_epi64(
+                    _mm256_srl_epi64(_mm256_xor_si256(carry, self.sign), self.carry_shift),
+                    self.carry_bias,
+                );
+                _mm256_add_epi64(source, incoming)
+            } else {
+                source
+            };
+            (low, _mm256_add_epi64(high, overflow))
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn round_bit(&self, low: __m256i) -> __m256i {
+        unsafe { _mm256_srl_epi64(low, self.round_shift) }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn round<const PAD: bool>(&self, low: __m256i) -> (__m256i, __m256i) {
+        unsafe {
+            let rounded = _mm256_srl_epi64(_mm256_add_epi64(low, self.half), self.padding);
+            let digit = _mm256_sub_epi64(
+                _mm256_xor_si256(_mm256_and_si256(rounded, self.digit_mask), self.digit_sign),
+                self.digit_sign,
+            );
+            let carry = _mm256_srl_epi64(_mm256_sub_epi64(rounded, digit), self.width);
+            (if PAD { _mm256_sll_epi64(digit, self.padding) } else { digit }, carry)
+        }
+    }
+}
+
+/// # Safety
+/// Requires AVX2. Slice lengths and radix parameters are checked before access.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn znx_normalize_floor_avx<const CARRY_IN: bool, const ROUND: bool>(
+    base2k: usize,
+    lsh: usize,
+    a: &[i64],
+    carry: &mut [i64],
+) {
+    assert!(a.len() >= carry.len());
+    unsafe {
+        let boundary = NormalizationBoundaryAvx::new(base2k, lsh, 0);
+        let end = carry.len() / 4 * 4;
+        for i in (0..end).step_by(4) {
+            let source = _mm256_loadu_si256(a.as_ptr().add(i).cast());
+            let incoming = if CARRY_IN {
+                _mm256_loadu_si256(carry.as_ptr().add(i).cast())
+            } else {
+                _mm256_setzero_si256()
+            };
+            let (low, mut high) = boundary.floor::<CARRY_IN>(source, incoming);
+            if ROUND {
+                high = _mm256_add_epi64(high, boundary.round_bit(low));
+            }
+            _mm256_storeu_si256(carry.as_mut_ptr().add(i).cast(), high);
+        }
+        poulpy_cpu_ref::reference::normalization::znx_normalize_floor_ref::<CARRY_IN, ROUND>(
+            base2k,
+            lsh,
+            &a[end..],
+            &mut carry[end..],
+        );
+    }
+}
+
+/// # Safety
+/// Requires AVX2. Slice lengths and radix parameters are checked before access.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn znx_normalize_round_avx<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i64],
+    carry: &mut [i64],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    unsafe {
+        let boundary = NormalizationBoundaryAvx::new(base2k, lsh, padding);
+        let end = res.len() / 4 * 4;
+        for i in (0..end).step_by(4) {
+            let source = _mm256_loadu_si256(a.as_ptr().add(i).cast());
+            let incoming = if CARRY_IN {
+                _mm256_loadu_si256(carry.as_ptr().add(i).cast())
+            } else {
+                _mm256_setzero_si256()
+            };
+            let (low, high) = boundary.floor::<CARRY_IN>(source, incoming);
+            let (digit, extra) = boundary.round::<PAD>(low);
+            _mm256_storeu_si256(res.as_mut_ptr().add(i).cast(), digit);
+            _mm256_storeu_si256(carry.as_mut_ptr().add(i).cast(), _mm256_add_epi64(high, extra));
+        }
+        poulpy_cpu_ref::reference::normalization::znx_normalize_round_ref::<CARRY_IN, PAD>(
+            base2k,
+            lsh,
+            padding,
+            &mut res[end..],
+            &a[end..],
+            &mut carry[end..],
+        );
+    }
+}
+
+/// # Safety
+/// Requires AVX2. Slice lengths and radix parameters are checked before access.
+#[inline]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn znx_normalize_round_assign_avx<const CARRY_IN: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    carry: &mut [i64],
+) {
+    assert!(carry.len() >= res.len());
+    unsafe {
+        let boundary = NormalizationBoundaryAvx::new(base2k, lsh, padding);
+        let end = res.len() / 4 * 4;
+        for i in (0..end).step_by(4) {
+            let source = _mm256_loadu_si256(res.as_ptr().add(i).cast());
+            let incoming = if CARRY_IN {
+                _mm256_loadu_si256(carry.as_ptr().add(i).cast())
+            } else {
+                _mm256_setzero_si256()
+            };
+            let (low, high) = boundary.floor::<CARRY_IN>(source, incoming);
+            let (digit, extra) = boundary.round::<true>(low);
+            _mm256_storeu_si256(res.as_mut_ptr().add(i).cast(), digit);
+            _mm256_storeu_si256(carry.as_mut_ptr().add(i).cast(), _mm256_add_epi64(high, extra));
+        }
+        poulpy_cpu_ref::reference::normalization::znx_normalize_round_assign_ref::<CARRY_IN>(
+            base2k,
+            lsh,
+            padding,
+            &mut res[end..],
+            &mut carry[end..],
+        );
+    }
+}

--- a/poulpy-cpu-avx512/Cargo.toml
+++ b/poulpy-cpu-avx512/Cargo.toml
@@ -64,3 +64,8 @@ required-features = ["enable-avx512f", "enable-ckks"]
 name = "light"
 harness = false
 required-features = ["enable-avx512f", "enable-ckks"]
+
+[[bench]]
+name = "normalize"
+harness = false
+required-features = ["enable-avx512f"]

--- a/poulpy-cpu-avx512/benches/normalize.rs
+++ b/poulpy-cpu-avx512/benches/normalize.rs
@@ -1,0 +1,28 @@
+//! Same-base and cross-base normalization at full and partial precision.
+use criterion::{criterion_group, criterion_main};
+use poulpy_bench::hal::suites::bench_normalization;
+use poulpy_cpu_avx512::{FFT64Avx512, NTT4x30Avx512};
+
+fn parallel(_c: &mut criterion::Criterion) {
+    #[cfg(feature = "enable-rayon")]
+    {
+        bench_normalization::<poulpy_cpu_avx512::FFT64Avx512Rayon>(_c);
+        bench_normalization::<poulpy_cpu_avx512::NTT4x30Avx512Rayon>(_c);
+    }
+}
+
+fn ifma(_c: &mut criterion::Criterion) {
+    #[cfg(feature = "enable-ifma")]
+    {
+        bench_normalization::<poulpy_cpu_avx512::NTT3x42Ifma>(_c);
+        #[cfg(feature = "enable-rayon")]
+        bench_normalization::<poulpy_cpu_avx512::NTT3x42IfmaRayon>(_c);
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = poulpy_bench::criterion_config();
+    targets = bench_normalization::<FFT64Avx512>, bench_normalization::<NTT4x30Avx512>, parallel, ifma
+}
+criterion_main!(benches);

--- a/poulpy-cpu-avx512/src/fft64/module.rs
+++ b/poulpy-cpu-avx512/src/fft64/module.rs
@@ -458,6 +458,37 @@ impl ZnxExtractDigitAddMul for FFT64Avx512 {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for FFT64Avx512 {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { crate::znx_avx512::znx_normalize_floor_avx512::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { crate::znx_avx512::znx_normalize_round_avx512::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        assert!(carry.len() >= res.len());
+        unsafe { crate::znx_avx512::znx_normalize_round_assign_avx512::<CARRY_IN>(base2k, lsh, padding, res, carry) }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/rayon.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/rayon.rs
@@ -251,6 +251,40 @@ impl ZnxExtractDigitAddMul for NTT3x42IfmaRayon {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT3x42IfmaRayon {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        <NTT3x42Ifma as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_floor::<CARRY_IN, ROUND>(
+            base2k, lsh, a, carry,
+        )
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        <NTT3x42Ifma as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round::<CARRY_IN, PAD>(
+            base2k, lsh, padding, res, a, carry,
+        )
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <NTT3x42Ifma as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round_assign::<CARRY_IN>(
+            base2k, lsh, padding, res, carry,
+        )
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT3x42Ifma as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }
@@ -345,6 +379,33 @@ impl I128BigOps for NTT3x42IfmaRayon {
 }
 
 impl I128NormalizeOps for NTT3x42IfmaRayon {
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        <NTT3x42Ifma as I128NormalizeOps>::nfc_add_small_carry(carry, a)
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT3x42Ifma as I128NormalizeOps>::znx_extract_digit_addmul_i128(base2k, lsh, res, src)
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        <NTT3x42Ifma as I128NormalizeOps>::nfc_normalize_floor::<CARRY_IN, ROUND>(base2k, lsh, a, carry)
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        <NTT3x42Ifma as I128NormalizeOps>::nfc_normalize_round::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry)
+    }
+
     const FUSE_NORMALIZE: bool = <NTT3x42Ifma as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
 
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_big.rs
@@ -97,6 +97,37 @@ impl BigWordHadamardProduct for NTT3x42Ifma {
 }
 
 impl I128NormalizeOps for NTT3x42Ifma {
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { vi128_add_small_assign_avx512(carry.len(), carry, a) }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe { crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<false, false>(base2k, lsh, base2k, res, src, &mut []) }
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= carry.len());
+        unsafe { crate::vec_znx_big_avx512::nfc_normalize_floor_avx512::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { crate::vec_znx_big_avx512::nfc_normalize_round_avx512::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
         assert!(src.len() >= res.len());
         unsafe {
@@ -121,6 +152,7 @@ impl I128NormalizeOps for NTT3x42Ifma {
 
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             unsafe { nfc_middle_step_avx512(base2k as u32, lsh as u32, res.len(), res, a, carry) }
         } else {
@@ -130,6 +162,7 @@ impl I128NormalizeOps for NTT3x42Ifma {
 
     #[inline(always)]
     fn nfc_middle_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             unsafe { nfc_middle_step_assign_avx512(base2k as u32, lsh as u32, res.len(), res, carry) }
         } else {
@@ -139,6 +172,7 @@ impl I128NormalizeOps for NTT3x42Ifma {
 
     #[inline(always)]
     fn nfc_middle_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             if O::SUB {
                 unsafe { nfc_middle_step_sub_assign_avx512(base2k as u32, lsh as u32, res.len(), res, a, carry) }
@@ -154,6 +188,7 @@ impl I128NormalizeOps for NTT3x42Ifma {
 
     #[inline(always)]
     fn nfc_final_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             unsafe { nfc_final_step_assign_avx512(base2k as u32, lsh as u32, res.len(), res, carry) }
         } else {
@@ -163,6 +198,7 @@ impl I128NormalizeOps for NTT3x42Ifma {
 
     #[inline(always)]
     fn nfc_final_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             if O::SUB {
                 unsafe { nfc_final_step_sub_assign_avx512(base2k as u32, lsh as u32, res.len(), res, carry) }

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/znx.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/znx.rs
@@ -217,6 +217,37 @@ impl ZnxExtractDigitAddMul for NTT3x42Ifma {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT3x42Ifma {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { crate::znx_avx512::znx_normalize_floor_avx512::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { crate::znx_avx512::znx_normalize_round_avx512::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        assert!(carry.len() >= res.len());
+        unsafe { crate::znx_avx512::znx_normalize_round_assign_avx512::<CARRY_IN>(base2k, lsh, padding, res, carry) }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon.rs
@@ -248,6 +248,40 @@ impl ZnxExtractDigitAddMul for NTT4x30Avx512Rayon {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Avx512Rayon {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        <NTT4x30Avx512 as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_floor::<CARRY_IN, ROUND>(
+            base2k, lsh, a, carry,
+        )
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        <NTT4x30Avx512 as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round::<CARRY_IN, PAD>(
+            base2k, lsh, padding, res, a, carry,
+        )
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        <NTT4x30Avx512 as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round_assign::<CARRY_IN>(
+            base2k, lsh, padding, res, carry,
+        )
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <NTT4x30Avx512 as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(
             base2k, lsh, res, src,
@@ -414,6 +448,33 @@ impl I128BigOps for NTT4x30Avx512Rayon {
 }
 
 impl I128NormalizeOps for NTT4x30Avx512Rayon {
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        <NTT4x30Avx512 as I128NormalizeOps>::nfc_add_small_carry(carry, a)
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        <NTT4x30Avx512 as I128NormalizeOps>::znx_extract_digit_addmul_i128(base2k, lsh, res, src)
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        <NTT4x30Avx512 as I128NormalizeOps>::nfc_normalize_floor::<CARRY_IN, ROUND>(base2k, lsh, a, carry)
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        <NTT4x30Avx512 as I128NormalizeOps>::nfc_normalize_round::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry)
+    }
+
     const FUSE_NORMALIZE: bool = <NTT4x30Avx512 as poulpy_cpu_ref::reference::ntt4x30::I128NormalizeOps>::FUSE_NORMALIZE;
 
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/vec_znx_big.rs
@@ -98,6 +98,37 @@ impl BigWordHadamardProduct for NTT4x30Avx512 {
 }
 
 impl I128NormalizeOps for NTT4x30Avx512 {
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { vi128_add_small_assign_avx512(carry.len(), carry, a) }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        assert!(src.len() >= res.len());
+        unsafe { crate::vec_znx_big_avx512::nfc_extract_normalize_avx512::<false, false>(base2k, lsh, base2k, res, src, &mut []) }
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= carry.len());
+        unsafe { crate::vec_znx_big_avx512::nfc_normalize_floor_avx512::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { crate::vec_znx_big_avx512::nfc_normalize_round_avx512::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
     fn znx_extract_digit_mul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
         assert!(src.len() >= res.len());
         unsafe {
@@ -122,6 +153,7 @@ impl I128NormalizeOps for NTT4x30Avx512 {
 
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             unsafe { nfc_middle_step_avx512(base2k as u32, lsh as u32, res.len(), res, a, carry) }
         } else {
@@ -131,6 +163,7 @@ impl I128NormalizeOps for NTT4x30Avx512 {
 
     #[inline(always)]
     fn nfc_middle_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             unsafe { nfc_middle_step_assign_avx512(base2k as u32, lsh as u32, res.len(), res, carry) }
         } else {
@@ -140,6 +173,7 @@ impl I128NormalizeOps for NTT4x30Avx512 {
 
     #[inline(always)]
     fn nfc_middle_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             if O::SUB {
                 unsafe { nfc_middle_step_sub_assign_avx512(base2k as u32, lsh as u32, res.len(), res, a, carry) }
@@ -155,6 +189,7 @@ impl I128NormalizeOps for NTT4x30Avx512 {
 
     #[inline(always)]
     fn nfc_final_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             unsafe { nfc_final_step_assign_avx512(base2k as u32, lsh as u32, res.len(), res, carry) }
         } else {
@@ -164,6 +199,7 @@ impl I128NormalizeOps for NTT4x30Avx512 {
 
     #[inline(always)]
     fn nfc_final_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if base2k <= 64 && res.len() >= 8 {
             if O::SUB {
                 unsafe { nfc_final_step_sub_assign_avx512(base2k as u32, lsh as u32, res.len(), res, carry) }

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/znx.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/znx.rs
@@ -218,6 +218,37 @@ impl ZnxExtractDigitAddMul for NTT4x30Avx512 {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for NTT4x30Avx512 {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        assert!(a.len() >= carry.len());
+        unsafe { crate::znx_avx512::znx_normalize_floor_avx512::<CARRY_IN, ROUND>(base2k, lsh, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
+        unsafe { crate::znx_avx512::znx_normalize_round_avx512::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry) }
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        assert!(carry.len() >= res.len());
+        unsafe { crate::znx_avx512::znx_normalize_round_assign_avx512::<CARRY_IN>(base2k, lsh, padding, res, carry) }
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         unsafe {
             crate::znx_avx512::znx_extract_digit_mul_avx512(base2k, lsh, res, src);

--- a/poulpy-cpu-avx512/src/vec_znx_big_avx512.rs
+++ b/poulpy-cpu-avx512/src/vec_znx_big_avx512.rs
@@ -26,6 +26,111 @@ use std::arch::x86_64::*;
 use itertools::izip;
 use poulpy_cpu_ref::reference::znx::{get_carry_i128, get_digit_i128};
 
+/// # Safety
+/// Requires AVX-512F.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn nfc_normalize_floor_avx512<const CARRY_IN: bool, const ROUND: bool>(
+    base2k: usize,
+    lsh: usize,
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= carry.len());
+    unsafe { nfc_normalize_boundary_avx512::<CARRY_IN, ROUND, false, false>(base2k, lsh, 0, &mut [], a, carry) }
+}
+
+/// # Safety
+/// Requires AVX-512F.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn nfc_normalize_round_avx512<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    unsafe { nfc_normalize_boundary_avx512::<CARRY_IN, false, true, PAD>(base2k, lsh, padding, res, a, carry) }
+}
+
+#[inline]
+#[target_feature(enable = "avx512f")]
+unsafe fn nfc_normalize_boundary_avx512<const CARRY_IN: bool, const ROUND: bool, const WRITE: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    unsafe {
+        let step = crate::znx_avx512::NormalizationBoundary512::new(base2k, lsh, padding);
+        let source_left = _mm512_set1_epi64((64 - base2k + lsh) as i64);
+        let carry_left = _mm512_set1_epi64((64 - base2k) as i64);
+        let round_shift = _mm512_set1_epi64((base2k - 1) as i64);
+        let zero = _mm512_setzero_si512();
+        let dl = _mm512_loadu_si512(DEINTERLEAVE_LO.as_ptr().cast());
+        let dh = _mm512_loadu_si512(DEINTERLEAVE_HI.as_ptr().cast());
+        let il = _mm512_loadu_si512(INTERLEAVE_LO.as_ptr().cast());
+        let ih = _mm512_loadu_si512(INTERLEAVE_HI.as_ptr().cast());
+        let n = if WRITE { res.len() } else { carry.len() };
+        let chunks = n / 8;
+        for i in 0..chunks {
+            let (a_lo, a_hi) = load8_i128(a.as_ptr().cast(), i, dl, dh);
+            let (c_lo, c_hi) = if CARRY_IN {
+                load8_i128(carry.as_ptr().cast(), i, dl, dh)
+            } else {
+                (zero, zero)
+            };
+            let (low, overflow) = step.low::<CARRY_IN>(a_lo, c_lo);
+            let source_lo = _mm512_or_si512(
+                _mm512_srlv_epi64(a_lo, step.source_bits),
+                _mm512_sllv_epi64(a_hi, source_left),
+            );
+            let source_hi = _mm512_srav_epi64(a_hi, step.source_bits);
+            let (high_lo, high_hi) = if CARRY_IN {
+                let carry_lo = _mm512_or_si512(_mm512_srlv_epi64(c_lo, step.base2k), _mm512_sllv_epi64(c_hi, carry_left));
+                let carry_hi = _mm512_srav_epi64(c_hi, step.base2k);
+                add8_i128(source_lo, source_hi, carry_lo, carry_hi)
+            } else {
+                (source_lo, source_hi)
+            };
+            let increment = if WRITE {
+                let (digit, round_carry) = step.round::<PAD>(low);
+                _mm512_storeu_si512(res.as_mut_ptr().add(8 * i).cast(), digit);
+                _mm512_add_epi64(overflow, round_carry)
+            } else if ROUND {
+                _mm512_add_epi64(overflow, _mm512_srlv_epi64(low, round_shift))
+            } else {
+                overflow
+            };
+            let (out_lo, out_hi) = add8_i128(high_lo, high_hi, increment, zero);
+            store8_i128(carry.as_mut_ptr().cast(), i, out_lo, out_hi, il, ih);
+        }
+        let end = chunks * 8;
+        if WRITE {
+            poulpy_cpu_ref::reference::normalization::nfc_normalize_round_ref::<CARRY_IN, PAD>(
+                base2k,
+                lsh,
+                padding,
+                &mut res[end..],
+                &a[end..],
+                &mut carry[end..],
+            );
+        } else {
+            poulpy_cpu_ref::reference::normalization::nfc_normalize_floor_ref::<CARRY_IN, ROUND>(
+                base2k,
+                lsh,
+                &a[end..],
+                &mut carry[end..],
+            );
+        }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Scalar fallback helpers (used as tails in AVX-512 kernels)
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1275,8 +1380,10 @@ pub(super) unsafe fn nfc_extract_normalize_avx512<const OVERWRITE: bool, const F
             poulpy_cpu_ref::reference::znx::znx_extract_digit_addmul_normalize_i128_ref::<OVERWRITE>(
                 base2k, lsh, res_base2k, res, src, carry,
             );
-        } else {
+        } else if OVERWRITE {
             poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, res, src);
+        } else {
+            poulpy_cpu_ref::reference::normalization::znx_extract_digit_addmul_i128_ref(base2k, lsh, res, src);
         }
         return;
     }
@@ -1328,8 +1435,15 @@ pub(super) unsafe fn nfc_extract_normalize_avx512<const OVERWRITE: bool, const F
                 &mut src[end..],
                 &mut carry[end..],
             );
-        } else {
+        } else if OVERWRITE {
             poulpy_cpu_ref::reference::znx::znx_extract_digit_mul_i128_ref(base2k, lsh, &mut res[end..], &mut src[end..]);
+        } else {
+            poulpy_cpu_ref::reference::normalization::znx_extract_digit_addmul_i128_ref(
+                base2k,
+                lsh,
+                &mut res[end..],
+                &mut src[end..],
+            );
         }
     }
 }

--- a/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
+++ b/poulpy-cpu-avx512/src/znx_avx512/normalization.rs
@@ -2,6 +2,194 @@
 
 use core::arch::x86_64::__m512i;
 
+pub(crate) struct NormalizationBoundary512 {
+    mask: __m512i,
+    source_mask: __m512i,
+    pub(crate) base2k: __m512i,
+    pub(crate) source_bits: __m512i,
+    lsh: __m512i,
+    padding: __m512i,
+    width: __m512i,
+    center: __m512i,
+    half: __m512i,
+}
+
+impl NormalizationBoundary512 {
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    pub(crate) unsafe fn new(base2k: usize, lsh: usize, padding: usize) -> Self {
+        use core::arch::x86_64::_mm512_set1_epi64;
+
+        assert!((1..=63).contains(&base2k));
+        assert!(lsh < base2k && padding < base2k);
+        Self {
+            mask: _mm512_set1_epi64(((1u64 << base2k) - 1) as i64),
+            source_mask: _mm512_set1_epi64(((1u64 << (base2k - lsh)) - 1) as i64),
+            base2k: _mm512_set1_epi64(base2k as i64),
+            source_bits: _mm512_set1_epi64((base2k - lsh) as i64),
+            lsh: _mm512_set1_epi64(lsh as i64),
+            padding: _mm512_set1_epi64(padding as i64),
+            width: _mm512_set1_epi64((base2k - padding) as i64),
+            center: _mm512_set1_epi64((64 - base2k + padding) as i64),
+            half: _mm512_set1_epi64(if padding == 0 { 0 } else { 1i64 << (padding - 1) }),
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    pub(crate) unsafe fn low<const CARRY_IN: bool>(&self, a: __m512i, carry: __m512i) -> (__m512i, __m512i) {
+        use core::arch::x86_64::*;
+
+        let source_low = _mm512_sllv_epi64(_mm512_and_si512(a, self.source_mask), self.lsh);
+        let sum = if CARRY_IN {
+            _mm512_add_epi64(source_low, _mm512_and_si512(carry, self.mask))
+        } else {
+            source_low
+        };
+        (_mm512_and_si512(sum, self.mask), _mm512_srlv_epi64(sum, self.base2k))
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn floor<const CARRY_IN: bool>(&self, a: __m512i, carry: __m512i) -> (__m512i, __m512i) {
+        use core::arch::x86_64::*;
+
+        let (low, overflow) = self.low::<CARRY_IN>(a, carry);
+        let high = _mm512_srav_epi64(a, self.source_bits);
+        let high = if CARRY_IN {
+            _mm512_add_epi64(high, _mm512_srav_epi64(carry, self.base2k))
+        } else {
+            high
+        };
+        (low, _mm512_add_epi64(high, overflow))
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    pub(crate) unsafe fn round<const PAD: bool>(&self, low: __m512i) -> (__m512i, __m512i) {
+        use core::arch::x86_64::*;
+
+        let rounded = _mm512_srlv_epi64(_mm512_add_epi64(low, self.half), self.padding);
+        let digit = _mm512_srav_epi64(_mm512_sllv_epi64(rounded, self.center), self.center);
+        let carry = _mm512_srlv_epi64(_mm512_sub_epi64(rounded, digit), self.width);
+        (if PAD { _mm512_sllv_epi64(digit, self.padding) } else { digit }, carry)
+    }
+}
+
+/// # Safety
+/// Requires AVX-512F.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn znx_normalize_floor_avx512<const CARRY_IN: bool, const ROUND: bool>(
+    base2k: usize,
+    lsh: usize,
+    a: &[i64],
+    carry: &mut [i64],
+) {
+    use core::arch::x86_64::*;
+
+    assert!(a.len() >= carry.len());
+    let step = NormalizationBoundary512::new(base2k, lsh, 0);
+    let round_shift = _mm512_set1_epi64((base2k - 1) as i64);
+    let end = carry.len() / 8 * 8;
+    for i in (0..end).step_by(8) {
+        let source = _mm512_loadu_si512(a.as_ptr().add(i).cast());
+        let incoming = if CARRY_IN {
+            _mm512_loadu_si512(carry.as_ptr().add(i).cast())
+        } else {
+            _mm512_setzero_si512()
+        };
+        let (low, high) = step.floor::<CARRY_IN>(source, incoming);
+        let out = if ROUND {
+            _mm512_add_epi64(high, _mm512_srlv_epi64(low, round_shift))
+        } else {
+            high
+        };
+        _mm512_storeu_si512(carry.as_mut_ptr().add(i).cast(), out);
+    }
+    poulpy_cpu_ref::reference::normalization::znx_normalize_floor_ref::<CARRY_IN, ROUND>(
+        base2k,
+        lsh,
+        &a[end..],
+        &mut carry[end..],
+    );
+}
+
+#[inline]
+#[target_feature(enable = "avx512f")]
+unsafe fn znx_normalize_round_chunks_avx512<const CARRY_IN: bool, const PAD: bool>(
+    step: &NormalizationBoundary512,
+    end: usize,
+    res: *mut i64,
+    a: *const i64,
+    carry: *mut i64,
+) {
+    use core::arch::x86_64::*;
+
+    for i in (0..end).step_by(8) {
+        let source = _mm512_loadu_si512(a.add(i).cast());
+        let incoming = if CARRY_IN {
+            _mm512_loadu_si512(carry.add(i).cast())
+        } else {
+            _mm512_setzero_si512()
+        };
+        let (low, high) = step.floor::<CARRY_IN>(source, incoming);
+        let (digit, round_carry) = step.round::<PAD>(low);
+        _mm512_storeu_si512(res.add(i).cast(), digit);
+        _mm512_storeu_si512(carry.add(i).cast(), _mm512_add_epi64(high, round_carry));
+    }
+}
+
+/// # Safety
+/// Requires AVX-512F.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn znx_normalize_round_avx512<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i64],
+    carry: &mut [i64],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    let step = NormalizationBoundary512::new(base2k, lsh, padding);
+    let end = res.len() / 8 * 8;
+    znx_normalize_round_chunks_avx512::<CARRY_IN, PAD>(&step, end, res.as_mut_ptr(), a.as_ptr(), carry.as_mut_ptr());
+    poulpy_cpu_ref::reference::normalization::znx_normalize_round_ref::<CARRY_IN, PAD>(
+        base2k,
+        lsh,
+        padding,
+        &mut res[end..],
+        &a[end..],
+        &mut carry[end..],
+    );
+}
+
+/// # Safety
+/// Requires AVX-512F.
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn znx_normalize_round_assign_avx512<const CARRY_IN: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    carry: &mut [i64],
+) {
+    assert!(carry.len() >= res.len());
+    let step = NormalizationBoundary512::new(base2k, lsh, padding);
+    let end = res.len() / 8 * 8;
+    znx_normalize_round_chunks_avx512::<CARRY_IN, true>(&step, end, res.as_mut_ptr(), res.as_ptr(), carry.as_mut_ptr());
+    poulpy_cpu_ref::reference::normalization::znx_normalize_round_assign_ref::<CARRY_IN>(
+        base2k,
+        lsh,
+        padding,
+        &mut res[end..],
+        &mut carry[end..],
+    );
+}
+
 /// Vector forms of normalisation constants (broadcast to all 8 lanes).
 ///
 /// Returns `(mask_k, sign_k, base2k_vec)`.

--- a/poulpy-cpu-rayon/src/fft64.rs
+++ b/poulpy-cpu-rayon/src/fft64.rs
@@ -213,6 +213,21 @@ impl ZnxExtractDigitAddMul for $rayon {
 
 impl poulpy_cpu_ref::reference::normalization::I64NormalizeOps for $rayon {
     #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        <$base as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_floor::<CARRY_IN, ROUND>(base2k, lsh, a, carry);
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(base2k: usize, lsh: usize, padding: usize, res: &mut [i64], a: &[i64], carry: &mut [i64]) {
+        <$base as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry);
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(base2k: usize, lsh: usize, padding: usize, res: &mut [i64], carry: &mut [i64]) {
+        <$base as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_normalize_round_assign::<CARRY_IN>(base2k, lsh, padding, res, carry);
+    }
+
+    #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         <$base as poulpy_cpu_ref::reference::normalization::I64NormalizeOps>::znx_extract_digit_mul(base2k, lsh, res, src);
     }

--- a/poulpy-cpu-rayon/src/normalize.rs
+++ b/poulpy-cpu-rayon/src/normalize.rs
@@ -117,7 +117,11 @@ pub fn vec_znx_normalize_assign_par<B, T>(
     res_col: usize,
     carry: &mut [i64],
 ) where
-    B: Backend<ZnxWord = i64> + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
+    B: Backend<ZnxWord = i64>
+        + I64NormalizeOps
+        + ZnxNormalizeFirstStepAssign
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxNormalizeFinalStepAssign,
     for<'x> B: Backend<BufRef<'x> = &'x [u8], BufMut<'x> = &'x mut [u8]>,
     B: 'static,
     T: RayonTuning,

--- a/poulpy-cpu-ref/Cargo.toml
+++ b/poulpy-cpu-ref/Cargo.toml
@@ -83,3 +83,7 @@ required-features = ["enable-core", "enable-ckks"]
 name = "light"
 harness = false
 required-features = ["enable-core", "enable-ckks"]
+
+[[bench]]
+name = "normalize"
+harness = false

--- a/poulpy-cpu-ref/benches/normalize.rs
+++ b/poulpy-cpu-ref/benches/normalize.rs
@@ -1,0 +1,11 @@
+//! Same-base and cross-base normalization at full and partial precision.
+use criterion::{criterion_group, criterion_main};
+use poulpy_bench::hal::suites::bench_normalization;
+use poulpy_cpu_ref::{FFT64Ref, NTT4x30Ref};
+
+criterion_group! {
+    name = benches;
+    config = poulpy_bench::criterion_config();
+    targets = bench_normalization::<FFT64Ref>, bench_normalization::<NTT4x30Ref>
+}
+criterion_main!(benches);

--- a/poulpy-cpu-ref/src/hal_defaults/vec_znx.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/vec_znx.rs
@@ -236,7 +236,7 @@ where
         res_col: usize,
         scratch: &mut ScratchArena<'_, BE>,
     ) where
-        BE: ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
+        BE: I64NormalizeOps + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
         for<'x> BE::BufMut<'x>: HostDataMut,
         for<'x> BE::BufMut<'x>: HostBufMut<'x>,
     {

--- a/poulpy-cpu-ref/src/reference/normalization.rs
+++ b/poulpy-cpu-ref/src/reference/normalization.rs
@@ -7,6 +7,35 @@ use poulpy_hal::reference::znx::{ZnxExtractDigitAddMul, get_carry_i64, get_carry
 /// Source and carry lengths must cover `res`; shorter slices panic before writing.
 /// Arithmetic bounds are those of the HAL extraction and normalization primitives.
 pub trait I64NormalizeOps: ZnxExtractDigitAddMul {
+    /// Floor-carry and boundary operations use the bounds of the corresponding reference kernels.
+    #[inline(always)]
+    fn znx_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+        znx_normalize_floor_ref::<CARRY_IN, ROUND>(base2k, lsh, a, carry);
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i64],
+        carry: &mut [i64],
+    ) {
+        znx_normalize_round_ref::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry);
+    }
+
+    #[inline(always)]
+    fn znx_normalize_round_assign<const CARRY_IN: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        carry: &mut [i64],
+    ) {
+        znx_normalize_round_assign_ref::<CARRY_IN>(base2k, lsh, padding, res, carry);
+    }
+
     #[inline(always)]
     fn znx_extract_digit_mul(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i64]) {
         znx_extract_digit_mul_ref(base2k, lsh, res, src);
@@ -95,5 +124,149 @@ pub fn znx_extract_digit_mul_i128_ref(base2k: usize, lsh: usize, res: &mut [i64]
         let digit = get_digit_i128(base2k, *s);
         *s = get_carry_i128(base2k, *s, digit);
         *r = (digit as i64).wrapping_shl(lsh as u32);
+    }
+}
+
+struct NormalizationBoundary {
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    width: usize,
+    mask: u64,
+    source_mask: u64,
+    half: u64,
+}
+
+impl NormalizationBoundary {
+    fn new(base2k: usize, lsh: usize, padding: usize) -> Self {
+        assert!((1..=63).contains(&base2k) && lsh < base2k && padding < base2k);
+        Self {
+            base2k,
+            lsh,
+            padding,
+            width: base2k - padding,
+            mask: (1u64 << base2k) - 1,
+            source_mask: (1u64 << (base2k - lsh)) - 1,
+            half: if padding == 0 { 0 } else { 1u64 << (padding - 1) },
+        }
+    }
+
+    #[inline(always)]
+    fn floor(&self, a: i64, carry: i64) -> (u64, i64) {
+        let low = ((a as u64 & self.source_mask) << self.lsh) + (carry as u64 & self.mask);
+        let high = (a >> (self.base2k - self.lsh)) + (carry >> self.base2k) + (low >> self.base2k) as i64;
+        (low & self.mask, high)
+    }
+
+    #[inline(always)]
+    fn round(&self, a: i64, carry: i64) -> (i64, i64) {
+        let (low, high) = self.floor(a, carry);
+        let rounded = (low + self.half) >> self.padding;
+        let digit = ((rounded << (64 - self.width)) as i64) >> (64 - self.width);
+        (
+            digit << self.padding,
+            high + (rounded.wrapping_sub(digit as u64) >> self.width) as i64,
+        )
+    }
+}
+
+// Decompose a shifted source and incoming floor carry without shifting the signed word.
+#[inline(always)]
+fn normalization_floor(base2k: usize, lsh: usize, a: i128, carry: i128) -> (u64, i128) {
+    let mask = (1u64 << base2k) - 1;
+    let source_bits = base2k - lsh;
+    let low = ((a as u64 & ((1u64 << source_bits) - 1)) << lsh) + (carry as u64 & mask);
+    let high = (a >> source_bits) + (carry >> base2k);
+    (low & mask, high + (low >> base2k) as i128)
+}
+
+/// Floor the shifted source plus carry; `ROUND` retains the top discarded bit.
+/// Radices are in `1..=63`, `lsh < base2k`, and input/carry magnitudes are at most `2^62`.
+pub fn znx_normalize_floor_ref<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i64], carry: &mut [i64]) {
+    assert!(a.len() >= carry.len());
+    let step = NormalizationBoundary::new(base2k, lsh, 0);
+    for (&source, carry) in a.iter().zip(carry.iter_mut()) {
+        let (low, high) = step.floor(source, if CARRY_IN { *carry } else { 0 });
+        *carry = high + if ROUND { (low >> (base2k - 1)) as i64 } else { 0 };
+    }
+}
+
+/// Round at `padding` low bits, center the retained digit and update its carry.
+/// `PAD` restores the cleared low bits; source and carry must cover `res`.
+pub fn znx_normalize_round_ref<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i64],
+    carry: &mut [i64],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    let step = NormalizationBoundary::new(base2k, lsh, padding);
+    for ((out, &source), carry) in res.iter_mut().zip(a).zip(carry.iter_mut()) {
+        let (digit, high) = step.round(source, if CARRY_IN { *carry } else { 0 });
+        *out = if PAD { digit } else { digit >> padding };
+        *carry = high;
+    }
+}
+
+/// In-place form of `znx_normalize_round_ref` with padded output.
+pub fn znx_normalize_round_assign_ref<const CARRY_IN: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    carry: &mut [i64],
+) {
+    assert!(carry.len() >= res.len());
+    let step = NormalizationBoundary::new(base2k, lsh, padding);
+    for (out, carry) in res.iter_mut().zip(carry.iter_mut()) {
+        (*out, *carry) = step.round(*out, if CARRY_IN { *carry } else { 0 });
+    }
+}
+
+/// Wide floor-carry step; input and carry magnitudes are at most `2^126`.
+/// Radices are in `1..=63`, `lsh < base2k`; source covers carry.
+pub fn nfc_normalize_floor_ref<const CARRY_IN: bool, const ROUND: bool>(
+    base2k: usize,
+    lsh: usize,
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= carry.len());
+    assert!((1..=63).contains(&base2k) && lsh < base2k);
+    for (&source, carry) in a.iter().zip(carry.iter_mut()) {
+        let (low, high) = normalization_floor(base2k, lsh, source, if CARRY_IN { *carry } else { 0 });
+        *carry = high + if ROUND { (low >> (base2k - 1)) as i128 } else { 0 };
+    }
+}
+
+/// Wide boundary rounding with the same digit contract as `znx_normalize_round_ref`.
+pub fn nfc_normalize_round_ref<const CARRY_IN: bool, const PAD: bool>(
+    base2k: usize,
+    lsh: usize,
+    padding: usize,
+    res: &mut [i64],
+    a: &[i128],
+    carry: &mut [i128],
+) {
+    assert!(a.len() >= res.len() && carry.len() >= res.len());
+    let step = NormalizationBoundary::new(base2k, lsh, padding);
+    for ((out, &source), carry) in res.iter_mut().zip(a).zip(carry.iter_mut()) {
+        let (low, high) = normalization_floor(base2k, lsh, source, if CARRY_IN { *carry } else { 0 });
+        let rounded = (low + step.half) >> padding;
+        let digit = ((rounded << (64 - step.width)) as i64) >> (64 - step.width);
+        *out = if PAD { digit << padding } else { digit };
+        *carry = high + ((rounded as i128 - digit as i128) >> step.width);
+    }
+}
+
+/// Extract a wide source digit and add its shifted value to a destination limb.
+pub fn znx_extract_digit_addmul_i128_ref(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+    assert!(src.len() >= res.len());
+    for (r, s) in res.iter_mut().zip(src.iter_mut()) {
+        let digit = get_digit_i128(base2k, *s);
+        *s = get_carry_i128(base2k, *s, digit);
+        *r = r.wrapping_add((digit as i64).wrapping_shl(lsh as u32));
     }
 }

--- a/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
@@ -38,8 +38,12 @@ use crate::{
         VecZnxToBackendRef, ZnxView, ZnxViewMut,
     },
     reference::{
+        normalization::I64NormalizeOps,
         vec_znx::VecZnxRangeMut,
-        znx::{get_carry_i128, get_digit_i128, znx_extract_digit_addmul_normalize_i128_ref, znx_extract_digit_mul_i128_ref},
+        znx::{
+            ZnxNormalizeMiddleStepAssign, get_carry_i128, get_digit_i128, znx_extract_digit_addmul_normalize_i128_ref,
+            znx_extract_digit_mul_i128_ref,
+        },
     },
     source::Source,
 };
@@ -52,68 +56,6 @@ use crate::{
 #[inline(always)]
 fn nfc_zero(x: &mut [i128]) {
     x.iter_mut().for_each(|v| *v = 0);
-}
-
-/// Add two `i128` slices in-place: `res += a`.
-#[inline(always)]
-fn nfc_add_assign(res: &mut [i128], a: &[i128]) {
-    res.iter_mut().zip(a.iter()).for_each(|(r, &ai)| *r = r.wrapping_add(ai));
-}
-
-/// Multiply an `i128` slice by `2^power` in-place (positive = left shift, negative = right shift).
-#[inline(always)]
-fn nfc_mul_pow2_assign(power: i64, x: &mut [i128]) {
-    if power > 0 {
-        x.iter_mut().for_each(|xi| *xi <<= power as u32);
-    } else if power < 0 {
-        x.iter_mut().for_each(|xi| *xi >>= (-power) as u32);
-    }
-}
-
-/// First carry-only step from the least significant `i128` limb of `a` (no prior carry).
-///
-/// Analogous to `znx_normalize_first_step_carry_only_ref` but for `i128`.
-#[inline(always)]
-fn nfc_first_carry_only(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
-    debug_assert!(a.len() <= carry.len());
-    debug_assert!(lsh < base2k);
-
-    if lsh == 0 {
-        a.iter().zip(carry.iter_mut()).for_each(|(&ai, c)| {
-            *c = get_carry_i128(base2k, ai, get_digit_i128(base2k, ai));
-        });
-    } else {
-        let base2k_lsh = base2k - lsh;
-        a.iter().zip(carry.iter_mut()).for_each(|(&ai, c)| {
-            *c = get_carry_i128(base2k_lsh, ai, get_digit_i128(base2k_lsh, ai));
-        });
-    }
-}
-
-/// Middle carry-only step from an inner `i128` limb of `a` (adds previous carry).
-///
-/// Analogous to `znx_normalize_middle_step_carry_only_ref` but for `i128`.
-#[inline(always)]
-fn nfc_middle_carry_only(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
-    debug_assert!(a.len() <= carry.len());
-    debug_assert!(lsh < base2k);
-
-    if lsh == 0 {
-        a.iter().zip(carry.iter_mut()).for_each(|(&ai, c)| {
-            let digit = get_digit_i128(base2k, ai);
-            let co = get_carry_i128(base2k, ai, digit);
-            let d_plus_c = digit + *c;
-            *c = co + get_carry_i128(base2k, d_plus_c, get_digit_i128(base2k, d_plus_c));
-        });
-    } else {
-        let base2k_lsh = base2k - lsh;
-        a.iter().zip(carry.iter_mut()).for_each(|(&ai, c)| {
-            let digit = get_digit_i128(base2k_lsh, ai);
-            let co = get_carry_i128(base2k_lsh, ai, digit);
-            let d_plus_c = (digit << lsh) + *c;
-            *c = co + get_carry_i128(base2k, d_plus_c, get_digit_i128(base2k, d_plus_c));
-        });
-    }
 }
 
 /// Middle normalization: convert `i128` input `a` + `i128` carry into `i64` output `res`,
@@ -287,73 +229,6 @@ fn nfc_final_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], 
     }
 }
 
-/// Normalize an `i128` limb into an `i128` intermediate (`a_norm`), with `i128` carry.
-///
-/// Used in the cross-base2k path to convert the `a` limb to the standard representation
-/// before bit-extraction. Analogous to `znx_normalize_middle_step_ref` but fully `i128`.
-#[inline(always)]
-fn nfc_middle_step_i128(base2k: usize, lsh: usize, a_norm: &mut [i128], a: &[i128], carry: &mut [i128]) {
-    debug_assert_eq!(a_norm.len(), a.len());
-    debug_assert!(a.len() <= carry.len());
-    debug_assert!(lsh < base2k);
-
-    if lsh == 0 {
-        izip!(a_norm.iter_mut(), a.iter(), carry.iter_mut()).for_each(|(x, &ai, c)| {
-            let digit = get_digit_i128(base2k, ai);
-            let co = get_carry_i128(base2k, ai, digit);
-            let d_plus_c = digit + *c;
-            let out = get_digit_i128(base2k, d_plus_c);
-            *x = out;
-            *c = co + get_carry_i128(base2k, d_plus_c, out);
-        });
-    } else {
-        let base2k_lsh = base2k - lsh;
-        izip!(a_norm.iter_mut(), a.iter(), carry.iter_mut()).for_each(|(x, &ai, c)| {
-            let digit = get_digit_i128(base2k_lsh, ai);
-            let co = get_carry_i128(base2k_lsh, ai, digit);
-            let d_plus_c = (digit << lsh) + *c;
-            let out = get_digit_i128(base2k, d_plus_c);
-            *x = out;
-            *c = co + get_carry_i128(base2k, d_plus_c, out);
-        });
-    }
-}
-
-/// Extract `base2k` bits from `src` (i128) shifted by `scale`, accumulate into `res` (i64).
-/// Updates `src` to hold the remaining carry.
-///
-/// Analogous to `znx_extract_digit_addmul_ref` but with `i128` src.
-#[inline(always)]
-fn nfc_extract_digit_addmul(base2k: usize, scale: usize, res: &mut [i64], src: &mut [i128]) {
-    for (r, s) in res.iter_mut().zip(src.iter_mut()) {
-        let digit = get_digit_i128(base2k, *s);
-        *s = get_carry_i128(base2k, *s, digit);
-        *r = r.wrapping_add((digit as i64).wrapping_shl(scale as u32));
-    }
-}
-
-#[inline]
-fn finish_nfc_normalized_limb(
-    base2k: usize,
-    active_size: usize,
-    padding: usize,
-    limb: usize,
-    digit: &mut [i64],
-    carry: &mut [i128],
-) {
-    if limb >= active_size {
-        digit.fill(0);
-    } else if limb + 1 == active_size && padding != 0 {
-        for (digit, carry) in digit.iter_mut().zip(carry.iter_mut()) {
-            let low_digit = get_digit_i128(padding, *digit as i128);
-            let rounded_value = *digit as i128 - low_digit;
-            let rounded_digit = get_digit_i128(base2k, rounded_value);
-            *digit = rounded_digit as i64;
-            *carry = carry.wrapping_add(get_carry_i128(base2k, rounded_value, rounded_digit));
-        }
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────────
 // Normalization internals
 // ──────────────────────────────────────────────────────────────────────────────
@@ -367,8 +242,6 @@ fn ntt4x30_vec_znx_big_normalize_inter<A, BE>(
     base2k: usize,
     res: &mut VecZnxRangeMut<'_>,
     res_size: usize,
-    active_size: usize,
-    padding: usize,
     res_offset: i64,
     a: &A,
     a_col: usize,
@@ -404,12 +277,14 @@ fn ntt4x30_vec_znx_big_normalize_inter<A, BE>(
 
     let a_out_range: usize = a_size.saturating_sub(a_start);
 
-    // Compute carry over discarded a limbs (those beyond res capacity).
+    // Floor discarded limbs and retain the rounding bit only at the cutoff.
     for j in 0..a_out_range {
-        if j == 0 {
-            nfc_first_carry_only(base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], carry);
-        } else {
-            nfc_middle_carry_only(base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], carry);
+        let source = &a.at(a_col, a_size - j - 1)[lo..hi];
+        match (j == 0, j + 1 == a_out_range) {
+            (true, false) => BE::nfc_normalize_floor::<false, false>(base2k, lsh_pos, source, carry),
+            (true, true) => BE::nfc_normalize_floor::<false, true>(base2k, lsh_pos, source, carry),
+            (false, false) => BE::nfc_normalize_floor::<true, false>(base2k, lsh_pos, source, carry),
+            (false, true) => BE::nfc_normalize_floor::<true, true>(base2k, lsh_pos, source, carry),
         }
     }
 
@@ -434,26 +309,23 @@ fn ntt4x30_vec_znx_big_normalize_inter<A, BE>(
             &a.at(a_col, a_start - j - 1)[lo..hi],
             carry,
         );
-        finish_nfc_normalized_limb(base2k, active_size, padding, res_limb, res.at_mut(res_limb), carry);
     }
 
     for j in (0..res_end).rev() {
         BE::znx_extract_digit_mul_i128(base2k, 0, res.at_mut(j), carry);
-        finish_nfc_normalized_limb(base2k, active_size, padding, j, res.at_mut(j), carry);
     }
 }
 
 /// Cross-base2k normalization: `a_base2k ≠ res_base2k`.
 ///
 /// Structurally identical to `vec_znx_normalize_cross_base2k` but with `i128` input
-/// limbs, `i128` carry buffers, and `i64` output.
+/// limbs and source carry, and `i64` normalized digits, output carry and output.
 #[allow(clippy::too_many_arguments)]
 fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
     res: &mut VecZnxRangeMut<'_>,
     res_size: usize,
     res_base2k: usize,
-    active_size: usize,
-    padding: usize,
+    res_k: usize,
     res_offset: i64,
     a: &A,
     a_base2k: usize,
@@ -471,13 +343,15 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
     let (lo, hi) = (coeff_start, coeff_start + coeff_len);
     let a_size = a.size();
 
-    // Partition the scratch: [a_norm | res_carry | a_carry]
-    let (a_norm, carry) = carry.split_at_mut(coeff_len);
-    let (res_carry, a_carry) = carry[..2 * coeff_len].split_at_mut(coeff_len);
-    nfc_zero(res_carry);
+    // Normalized source digits and output carries fit in i64; source carries stay wide.
+    let (small, carry) = carry.split_at_mut(coeff_len);
+    let (a_norm, res_carry) = bytemuck::cast_slice_mut::<i128, i64>(small).split_at_mut(coeff_len);
+    let a_carry = &mut carry[..coeff_len];
+    res_carry.fill(0);
 
     let a_tot_bits: usize = a_size * a_base2k;
-    let res_tot_bits: usize = res_size * res_base2k;
+    let res_tot_bits = res_k;
+    let drops_precision = a_tot_bits as i128 > res_k as i128 + res_offset as i128;
 
     let mut lsh: i64 = res_offset % a_base2k as i64;
     let mut limbs_offset: i64 = res_offset / a_base2k as i64;
@@ -507,20 +381,24 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
         return;
     }
 
-    // Compute carry over the a limbs that lie beyond the res precision range.
+    // Floor the discarded limbs; only the boundary contributes rounding.
     let a_out_range: usize = a_size.saturating_sub(a_start);
-    for j in 0..a_out_range {
-        if j == 0 {
-            nfc_first_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
-        } else {
-            nfc_middle_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
+    let take = (a_tot_bits - a_start_bit) % a_base2k;
+    if a_out_range != 0 {
+        for j in (a_start..a_size).rev() {
+            let source = &a.at(a_col, j)[lo..hi];
+            match (j + 1 == a_size, take == 0 && j == a_start) {
+                (true, false) => BE::nfc_normalize_floor::<false, false>(a_base2k, lsh_pos, source, a_carry),
+                (true, true) => BE::nfc_normalize_floor::<false, true>(a_base2k, lsh_pos, source, a_carry),
+                (false, false) => BE::nfc_normalize_floor::<true, false>(a_base2k, lsh_pos, source, a_carry),
+                (false, true) => BE::nfc_normalize_floor::<true, true>(a_base2k, lsh_pos, source, a_carry),
+            }
         }
-    }
-    if a_out_range == 0 {
+    } else if !drops_precision && take == 0 {
         nfc_zero(a_carry);
     }
 
-    let mut res_acc_left: usize = res_base2k;
+    let mut res_acc_left = res_start_bit - (res_start - 1) * res_base2k;
     let mut res_limb: usize = res_start - 1;
     let mut initialized = false;
 
@@ -532,40 +410,34 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
 
         let mut a_take_left: usize = a_base2k;
 
-        // Normalize the j-th limb of a into a_norm (i128→i128, with i128 carry).
-        nfc_middle_step_i128(a_base2k, lsh_pos, a_norm, a_slice, a_carry);
-
-        if j == 0 {
-            if !(a_tot_bits - a_start_bit).is_multiple_of(a_base2k) {
-                let take: usize = (a_tot_bits - a_start_bit) % a_base2k;
-                nfc_mul_pow2_assign(-(take as i64), a_norm);
-                a_take_left -= take;
-            } else if !(res_tot_bits - res_start_bit).is_multiple_of(res_base2k) {
-                res_acc_left -= (res_tot_bits - res_start_bit) % res_base2k;
+        if j == 0 && (drops_precision || take != 0) {
+            if a_out_range != 0 {
+                BE::nfc_normalize_round::<true, false>(a_base2k, lsh_pos, take, a_norm, a_slice, a_carry);
+            } else {
+                BE::nfc_normalize_round::<false, false>(a_base2k, lsh_pos, take, a_norm, a_slice, a_carry);
             }
+            a_take_left -= take;
+        } else {
+            BE::nfc_middle_step(a_base2k, lsh_pos, a_norm, a_slice, a_carry);
         }
 
         'inner: loop {
             let res_slice = res.at_mut(res_limb);
             let a_take: usize = a_base2k.min(a_take_left).min(res_acc_left);
 
-            let flushed = BE::FUSE_NORMALIZE && a_take != 0 && a_take == res_acc_left;
+            let flushed = a_take != 0 && a_take == res_acc_left;
             if a_take != 0 {
                 let scale: usize = res_base2k - res_acc_left;
                 if flushed {
                     if initialized {
-                        BE::znx_extract_digit_addmul_normalize_i128::<false>(
-                            a_take, scale, res_base2k, res_slice, a_norm, res_carry,
-                        );
+                        BE::znx_extract_digit_addmul_normalize::<false>(a_take, scale, res_base2k, res_slice, a_norm, res_carry);
                     } else {
-                        BE::znx_extract_digit_addmul_normalize_i128::<true>(
-                            a_take, scale, res_base2k, res_slice, a_norm, res_carry,
-                        );
+                        BE::znx_extract_digit_addmul_normalize::<true>(a_take, scale, res_base2k, res_slice, a_norm, res_carry);
                     }
                 } else if initialized {
-                    nfc_extract_digit_addmul(a_take, scale, res_slice, a_norm);
+                    BE::znx_extract_digit_addmul(a_take, scale, res_slice, a_norm);
                 } else {
-                    BE::znx_extract_digit_mul_i128(a_take, scale, res_slice, a_norm);
+                    BE::znx_extract_digit_mul(a_take, scale, res_slice, a_norm);
                 }
                 initialized = true;
                 a_take_left -= a_take;
@@ -574,24 +446,22 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
 
             if res_acc_left == 0 || a_limb == 0 {
                 if a_limb == 0 && a_take_left == 0 {
-                    nfc_add_assign(a_carry, a_norm);
+                    BE::nfc_add_small_carry(a_carry, a_norm);
                     if res_acc_left != 0 {
                         let scale: usize = res_base2k - res_acc_left;
-                        nfc_extract_digit_addmul(res_acc_left, scale, res_slice, a_carry);
+                        BE::znx_extract_digit_addmul_i128(res_acc_left, scale, res_slice, a_carry);
                     }
                     if !flushed {
-                        BE::nfc_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                        BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
                     }
-                    nfc_add_assign(res_carry, a_carry);
-                    finish_nfc_normalized_limb(res_base2k, active_size, padding, res_limb, res_slice, res_carry);
+                    BE::nfc_add_small_carry(a_carry, res_carry);
+
                     break 'outer;
                 }
 
                 if !flushed {
-                    BE::nfc_middle_step_assign(res_base2k, 0, res_slice, res_carry);
+                    BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
                 }
-
-                finish_nfc_normalized_limb(res_base2k, active_size, padding, res_limb, res_slice, res_carry);
 
                 if res_limb == 0 {
                     break 'outer;
@@ -603,7 +473,7 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
             }
 
             if a_take_left == 0 {
-                nfc_add_assign(a_carry, a_norm);
+                BE::nfc_add_small_carry(a_carry, a_norm);
                 break 'inner;
             }
         }
@@ -611,10 +481,8 @@ fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
 
     // Write the remaining more significant digits.
     if res_end != 0 {
-        let carry_to_use = if a_start == a_end { a_carry } else { res_carry };
         for j in (0..res_end).rev() {
-            BE::znx_extract_digit_mul_i128(res_base2k, 0, res.at_mut(j), carry_to_use);
-            finish_nfc_normalized_limb(res_base2k, active_size, padding, j, res.at_mut(j), carry_to_use);
+            BE::znx_extract_digit_mul_i128(res_base2k, 0, res.at_mut(j), a_carry);
         }
     }
 }
@@ -754,8 +622,39 @@ pub trait I128BigOps {
 /// Input limbs and incoming carries must have magnitude at most `2^126`;
 /// shifted digits and destination sums must be representable. These bounds
 /// include the centered NTT4x30 IDFT output, whose magnitude is below `2^119`.
-pub trait I128NormalizeOps {
-    /// Selects the fused flush in the shared CPU loop.
+pub trait I128NormalizeOps: I64NormalizeOps + ZnxNormalizeMiddleStepAssign {
+    #[inline(always)]
+    fn nfc_add_small_carry(carry: &mut [i128], a: &[i64]) {
+        assert!(a.len() >= carry.len());
+        for (carry, &digit) in carry.iter_mut().zip(a) {
+            *carry += digit as i128;
+        }
+    }
+
+    #[inline(always)]
+    fn znx_extract_digit_addmul_i128(base2k: usize, lsh: usize, res: &mut [i64], src: &mut [i128]) {
+        crate::reference::normalization::znx_extract_digit_addmul_i128_ref(base2k, lsh, res, src);
+    }
+
+    /// Floor-carry and boundary operations retain the reference kernels' magnitude bounds.
+    #[inline(always)]
+    fn nfc_normalize_floor<const CARRY_IN: bool, const ROUND: bool>(base2k: usize, lsh: usize, a: &[i128], carry: &mut [i128]) {
+        crate::reference::normalization::nfc_normalize_floor_ref::<CARRY_IN, ROUND>(base2k, lsh, a, carry);
+    }
+
+    #[inline(always)]
+    fn nfc_normalize_round<const CARRY_IN: bool, const PAD: bool>(
+        base2k: usize,
+        lsh: usize,
+        padding: usize,
+        res: &mut [i64],
+        a: &[i128],
+        carry: &mut [i128],
+    ) {
+        crate::reference::normalization::nfc_normalize_round_ref::<CARRY_IN, PAD>(base2k, lsh, padding, res, a, carry);
+    }
+
+    /// Retained for compatibility; cross-base extraction now uses the i64 kernels.
     const FUSE_NORMALIZE: bool = true;
 
     /// Requires `1 <= base2k`, `base2k + lsh <= 63` and `src.len() >= res.len()`.
@@ -781,6 +680,7 @@ pub trait I128NormalizeOps {
     /// Equivalent to the private `nfc_middle_step` helper.
     #[inline(always)]
     fn nfc_middle_step(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
         if lsh == 0 {
             izip!(res.iter_mut(), a.iter(), carry.iter_mut()).for_each(|(r, &ai, c)| {
                 let digit = get_digit_i128(base2k, ai);
@@ -806,6 +706,7 @@ pub trait I128NormalizeOps {
     /// Fused middle step for `res ±= normalize(a)`.  `O = AddOp` adds; `O = SubOp` subtracts.
     #[inline(always)]
     fn nfc_middle_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], a: &[i128], carry: &mut [i128]) {
+        assert!(a.len() >= res.len() && carry.len() >= res.len());
         nfc_middle_step_into::<O>(base2k, lsh, res, a, carry);
     }
 
@@ -814,6 +715,7 @@ pub trait I128NormalizeOps {
     /// Equivalent to the private `nfc_middle_step_assign` helper.
     #[inline(always)]
     fn nfc_middle_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if lsh == 0 {
             res.iter_mut().zip(carry.iter_mut()).for_each(|(r, c)| {
                 let ri = *r as i128;
@@ -843,6 +745,7 @@ pub trait I128NormalizeOps {
     /// Equivalent to the private `nfc_final_step_assign` helper.
     #[inline(always)]
     fn nfc_final_step_assign(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         if lsh == 0 {
             res.iter_mut().zip(carry.iter_mut()).for_each(|(r, c)| {
                 let ri = *r as i128;
@@ -860,6 +763,7 @@ pub trait I128NormalizeOps {
     /// Fused final step for `res ±= normalize(a)`.  `O = AddOp` adds; `O = SubOp` subtracts.
     #[inline(always)]
     fn nfc_final_step_into<O: AssignOp>(base2k: usize, lsh: usize, res: &mut [i64], carry: &mut [i128]) {
+        assert!(carry.len() >= res.len());
         nfc_final_step_into::<O>(base2k, lsh, res, carry);
     }
 }
@@ -1383,7 +1287,60 @@ pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
     let active_size = res_k.div_ceil(res_base2k);
     let padding = (res_base2k - res_k % res_base2k) % res_base2k;
     let input = a.to_backend_ref();
-    if crate::reference::vec_znx::normalize_needs_exact(input.size(), a_base2k, size, res_base2k, res_offset) {
+    let partial = res_k != size * res_base2k;
+    if res_base2k == a_base2k
+        && res_base2k <= 63
+        && (partial
+            || crate::reference::vec_znx::normalize_needs_exact(input.size(), a_base2k, active_size, res_base2k, res_offset))
+    {
+        let limb_offset = res_offset.div_euclid(res_base2k as i64);
+        let boundary = (active_size as i64 - 1).saturating_add(limb_offset);
+        if (0..input.size() as i64).contains(&boundary) {
+            let lsh = res_offset.rem_euclid(res_base2k as i64) as usize;
+            let carry = &mut carry[..coeff_len];
+            for j in (boundary as usize + 1..input.size()).rev() {
+                let source = &input.at(a_col, j)[coeff_start..coeff_start + coeff_len];
+                match (j + 1 == input.size(), padding == 0 && j == boundary as usize + 1) {
+                    (true, false) => BE::nfc_normalize_floor::<false, false>(res_base2k, lsh, source, carry),
+                    (true, true) => BE::nfc_normalize_floor::<false, true>(res_base2k, lsh, source, carry),
+                    (false, false) => BE::nfc_normalize_floor::<true, false>(res_base2k, lsh, source, carry),
+                    (false, true) => BE::nfc_normalize_floor::<true, true>(res_base2k, lsh, source, carry),
+                }
+            }
+            let source = &input.at(a_col, boundary as usize)[coeff_start..coeff_start + coeff_len];
+            if boundary as usize + 1 < input.size() {
+                BE::nfc_normalize_round::<true, true>(res_base2k, lsh, padding, res.at_mut(active_size - 1), source, carry);
+            } else {
+                BE::nfc_normalize_round::<false, true>(res_base2k, lsh, padding, res.at_mut(active_size - 1), source, carry);
+            }
+            for j in (0..active_size - 1).rev() {
+                let source = j as i64 + limb_offset;
+                if source >= 0 {
+                    BE::nfc_middle_step(
+                        res_base2k,
+                        lsh,
+                        res.at_mut(j),
+                        &input.at(a_col, source as usize)[coeff_start..coeff_start + coeff_len],
+                        carry,
+                    );
+                } else {
+                    BE::znx_extract_digit_mul_i128(res_base2k, 0, res.at_mut(j), carry);
+                }
+            }
+            for j in active_size..size {
+                res.at_mut(j).fill(0);
+            }
+            return;
+        }
+    }
+    let needs_exact = if a_base2k == res_base2k {
+        crate::reference::vec_znx::normalize_needs_exact(input.size(), a_base2k, active_size, res_base2k, res_offset)
+            || (partial && input.size() as i128 * a_base2k as i128 > res_k as i128 + res_offset as i128)
+    } else {
+        res_base2k > 62
+            || crate::reference::vec_znx::normalize_cross_needs_exact(input.size(), a_base2k, res_base2k, res_k, res_offset)
+    };
+    if needs_exact {
         for i in 0..coeff_len {
             crate::reference::vec_znx::normalize_exact::<false, _, _>(
                 |j| input.at(a_col, j)[coeff_start + i],
@@ -1403,9 +1360,7 @@ pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
         ntt4x30_vec_znx_big_normalize_inter(
             res_base2k,
             &mut res,
-            size,
             active_size,
-            padding,
             res_offset,
             a,
             a_col,
@@ -1416,10 +1371,9 @@ pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
     } else {
         ntt4x30_vec_znx_big_normalize_cross(
             &mut res,
-            size,
-            res_base2k,
             active_size,
-            padding,
+            res_base2k,
+            res_k,
             res_offset,
             a,
             a_base2k,
@@ -1428,6 +1382,9 @@ pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
             coeff_len,
             carry,
         );
+    }
+    for j in active_size..size {
+        res.at_mut(j).fill(0);
     }
 }
 

--- a/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
+++ b/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
@@ -30,29 +30,6 @@ pub fn vec_znx_normalize_tmp_bytes(n: usize) -> usize {
 }
 
 #[inline]
-fn split_digit(base2k: usize, value: i128) -> (i64, i128) {
-    let modulus = 1i128 << base2k;
-    let half = modulus >> 1;
-    let unsigned = value.rem_euclid(modulus);
-    let digit = if unsigned >= half { unsigned - modulus } else { unsigned };
-    (digit as i64, (value - digit) >> base2k)
-}
-
-#[inline]
-fn finish_normalized_limb(base2k: usize, active_size: usize, padding: usize, limb: usize, digit: &mut [i64], carry: &mut [i64]) {
-    if limb >= active_size {
-        digit.fill(0);
-    } else if limb + 1 == active_size && padding != 0 {
-        for (digit, carry) in digit.iter_mut().zip(carry.iter_mut()) {
-            let low_digit = split_digit(padding, *digit as i128).0;
-            let (rounded_digit, rounding_carry) = split_digit(base2k, *digit as i128 - low_digit as i128);
-            *digit = rounded_digit;
-            *carry = carry.wrapping_add(rounding_carry as i64);
-        }
-    }
-}
-
-#[inline]
 pub(crate) fn normalize_needs_exact(a_size: usize, a_base2k: usize, res_size: usize, res_base2k: usize, offset: i64) -> bool {
     if a_size == 0 || res_size == 0 || a_base2k > 63 || res_base2k > 63 {
         return true;
@@ -66,6 +43,17 @@ pub(crate) fn normalize_needs_exact(a_size: usize, a_base2k: usize, res_size: us
         a_bits - res_bits
     };
     offset < min_offset || offset >= a_bits
+}
+
+#[inline]
+pub(crate) fn normalize_cross_needs_exact(a_size: usize, a_base2k: usize, res_base2k: usize, res_k: usize, offset: i64) -> bool {
+    if a_size == 0 || !(1..=63).contains(&a_base2k) || !(1..=63).contains(&res_base2k) {
+        return true;
+    }
+    let a_bits = a_size as i128 * a_base2k as i128;
+    let aligned_offset = offset.div_euclid(a_base2k as i64) as i128 * a_base2k as i128;
+    // The slice traversal needs a source limb at the rounding boundary.
+    a_bits + res_k as i128 > i64::MAX as i128 || res_k as i128 + aligned_offset <= 0 || offset as i128 >= a_bits
 }
 
 pub(crate) struct VecZnxRangeMut<'a> {
@@ -616,7 +604,59 @@ pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
     }
     let active_size = res_k.div_ceil(res_base2k);
     let padding = (res_base2k - res_k % res_base2k) % res_base2k;
-    if normalize_needs_exact(a.size(), a_base2k, size, res_base2k, res_offset) {
+    let partial = res_k != size * res_base2k;
+    if res_base2k == a_base2k
+        && res_base2k <= 63
+        && (partial || normalize_needs_exact(a.size(), a_base2k, active_size, res_base2k, res_offset))
+    {
+        let limb_offset = res_offset.div_euclid(res_base2k as i64);
+        let boundary = (active_size as i64 - 1).saturating_add(limb_offset);
+        if (0..a.size() as i64).contains(&boundary) {
+            let lsh = res_offset.rem_euclid(res_base2k as i64) as usize;
+            let carry = &mut carry[..coeff_len];
+            let discarded = boundary as usize + 1 < a.size();
+            for j in (boundary as usize + 1..a.size()).rev() {
+                let source = &a.at(a_col, j)[coeff_start..coeff_start + coeff_len];
+                match (j + 1 == a.size(), padding == 0 && j == boundary as usize + 1) {
+                    (true, false) => BE::znx_normalize_floor::<false, false>(res_base2k, lsh, source, carry),
+                    (true, true) => BE::znx_normalize_floor::<false, true>(res_base2k, lsh, source, carry),
+                    (false, false) => BE::znx_normalize_floor::<true, false>(res_base2k, lsh, source, carry),
+                    (false, true) => BE::znx_normalize_floor::<true, true>(res_base2k, lsh, source, carry),
+                }
+            }
+            let source = &a.at(a_col, boundary as usize)[coeff_start..coeff_start + coeff_len];
+            if discarded {
+                BE::znx_normalize_round::<true, true>(res_base2k, lsh, padding, res.at_mut(active_size - 1), source, carry);
+            } else {
+                BE::znx_normalize_round::<false, true>(res_base2k, lsh, padding, res.at_mut(active_size - 1), source, carry);
+            }
+            for j in (0..active_size - 1).rev() {
+                let source = j as i64 + limb_offset;
+                if source >= 0 {
+                    BE::znx_normalize_middle_step::<true>(
+                        res_base2k,
+                        lsh,
+                        res.at_mut(j),
+                        &a.at(a_col, source as usize)[coeff_start..coeff_start + coeff_len],
+                        carry,
+                    );
+                } else {
+                    BE::znx_extract_digit_mul(res_base2k, 0, res.at_mut(j), carry);
+                }
+            }
+            for j in active_size..size {
+                res.at_mut(j).fill(0);
+            }
+            return;
+        }
+    }
+    let drops_precision = a.size() as i128 * a_base2k as i128 > res_k as i128 + res_offset as i128;
+    let needs_exact = if res_base2k == a_base2k {
+        normalize_needs_exact(a.size(), a_base2k, active_size, res_base2k, res_offset) || (partial && drops_precision)
+    } else {
+        normalize_cross_needs_exact(a.size(), a_base2k, res_base2k, res_k, res_offset)
+    };
+    if needs_exact {
         for i in 0..coeff_len {
             normalize_exact::<true, _, _>(
                 |j| a.at(a_col, j)[coeff_start + i] as i128,
@@ -635,9 +675,7 @@ pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
         true => vec_znx_normalize_inter_base2k::<BE>(
             res_base2k,
             &mut res,
-            size,
             active_size,
-            padding,
             res_offset,
             a,
             a_col,
@@ -647,10 +685,9 @@ pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
         ),
         false => vec_znx_normalize_cross_base2k::<BE>(
             &mut res,
-            size,
-            res_base2k,
             active_size,
-            padding,
+            res_base2k,
+            res_k,
             res_offset,
             a,
             a_base2k,
@@ -660,6 +697,9 @@ pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
             carry,
         ),
     }
+    for j in active_size..size {
+        res.at_mut(j).fill(0);
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -667,8 +707,6 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
     base2k: usize,
     res: &mut VecZnxRangeMut<'r>,
     res_size: usize,
-    active_size: usize,
-    padding: usize,
     res_offset: i64,
     a: &VecZnxBackendRef<'a, BE>,
     a_col: usize,
@@ -742,13 +780,11 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
             &a.at(a_col, a_start - j - 1)[lo..hi],
             carry,
         );
-        finish_normalized_limb(base2k, active_size, padding, res_limb, res.at_mut(res_limb), carry);
     }
 
     // Propagates the carry over the non-overlapping limbs between res and a
     for j in (0..res_end).rev() {
         BE::znx_extract_digit_mul(base2k, 0, res.at_mut(j), carry);
-        finish_normalized_limb(base2k, active_size, padding, j, res.at_mut(j), carry);
     }
 }
 
@@ -757,8 +793,7 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
     res: &mut VecZnxRangeMut<'r>,
     res_size: usize,
     res_base2k: usize,
-    active_size: usize,
-    padding: usize,
+    res_k: usize,
     res_offset: i64,
     a: &VecZnxBackendRef<'a, BE>,
     a_base2k: usize,
@@ -792,7 +827,8 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
 
     // Total precision (in bits) that `a` and `res` can represent.
     let a_tot_bits: usize = a_size * a_base2k;
-    let res_tot_bits: usize = res_size * res_base2k;
+    let res_tot_bits: usize = res_k;
+    let drops_precision = a_tot_bits as i128 > res_k as i128 + res_offset as i128;
 
     // Derive intra-limb shift and cross-limb offset.
     let mut lsh: i64 = res_offset % a_base2k as i64;
@@ -830,26 +866,25 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
         return;
     }
 
-    // Limbs of `a` that have a greater precision than `res`.
-    let a_out_range: usize = a_size.saturating_sub(a_start);
-
-    for j in 0..a_out_range {
-        if j == 0 {
-            BE::znx_normalize_first_step_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
-        } else {
-            BE::znx_normalize_middle_step_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
+    // Floor the discarded limbs; only the boundary contributes rounding.
+    let a_out_range = a_size.saturating_sub(a_start);
+    let take = (a_tot_bits - a_start_bit) % a_base2k;
+    if a_out_range != 0 {
+        for j in (a_start..a_size).rev() {
+            let source = &a.at(a_col, j)[lo..hi];
+            match (j + 1 == a_size, take == 0 && j == a_start) {
+                (true, false) => BE::znx_normalize_floor::<false, false>(a_base2k, lsh_pos, source, a_carry),
+                (true, true) => BE::znx_normalize_floor::<false, true>(a_base2k, lsh_pos, source, a_carry),
+                (false, false) => BE::znx_normalize_floor::<true, false>(a_base2k, lsh_pos, source, a_carry),
+                (false, true) => BE::znx_normalize_floor::<true, true>(a_base2k, lsh_pos, source, a_carry),
+            }
         }
-    }
-
-    // Zero carry if the above loop didn't trigger.
-    if a_out_range == 0 {
+    } else if !drops_precision {
         BE::znx_zero(a_carry);
     }
 
-    // How much is left to accumulate to fill a limb of `res`.
-    let mut res_acc_left: usize = res_base2k;
+    let mut res_acc_left = res_start_bit - (res_start - 1) * res_base2k;
 
-    // Starting limb of `res`.
     let mut res_limb: usize = res_start - 1;
     let mut initialized = false;
 
@@ -867,31 +902,18 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
         // be flushed on res.
         let mut a_take_left: usize = a_base2k;
 
-        // Normalizes the j-th limb of a and store the results into `a_norm``.
-        // This step is required to avoid overflow in the next step,
-        // which assumes that |a| is bounded by 2^{a_base2k -1} (i.e. normalized).
-        BE::znx_normalize_middle_step::<true>(a_base2k, lsh_pos, a_norm, a_slice, a_carry);
-
-        // In the first iteration we need to match the precision `res` and `a`.
-        if j == 0 {
-            // Case where `a` has more precision than `res` (after taking into account the offset)
-            //
-            // For example:
-            //
-            // a:      [x  x  x  x  x][x  x  x  x  x][x  x  x  x  x][x  x  x  x  x]
-            // res: [x  x  x  x  x  x][x  x  x  x  x  x][x  x  x  x  x  x]
-            if !(a_tot_bits - a_start_bit).is_multiple_of(a_base2k) {
-                let take: usize = (a_tot_bits - a_start_bit) % a_base2k;
+        if j == 0 && drops_precision {
+            if a_out_range != 0 {
+                BE::znx_normalize_round::<true, false>(a_base2k, lsh_pos, take, a_norm, a_slice, a_carry);
+            } else {
+                BE::znx_normalize_round::<false, false>(a_base2k, lsh_pos, take, a_norm, a_slice, a_carry);
+            }
+            a_take_left -= take;
+        } else {
+            BE::znx_normalize_middle_step::<true>(a_base2k, lsh_pos, a_norm, a_slice, a_carry);
+            if j == 0 && take != 0 {
                 BE::znx_mul_power_of_two_assign(-(take as i64), a_norm);
                 a_take_left -= take;
-            // Case where `res` has more precision than `a` (after taking into account the offset)
-            //
-            // For example:
-            //
-            // a:    [x  x  x  x  x][x  x  x  x  x][x  x  x  x  x][x  x  x  x  x]
-            // res:           [x  x  x  x  x  x][x  x  x  x  x  x][x  x  x  x  x  x]
-            } else if !(res_tot_bits - res_start_bit).is_multiple_of(res_base2k) {
-                res_acc_left -= (res_tot_bits - res_start_bit) % res_base2k;
             }
         }
 
@@ -962,7 +984,6 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
                     // Previous step might not consume all bits of a_carry
                     // Extraction reduces a_carry before adding the bounded result carry.
                     BE::znx_add_assign(res_carry, a_carry);
-                    finish_normalized_limb(res_base2k, active_size, padding, res_limb, res_slice, res_carry);
 
                     // We are done, so breaks out of the loop (yes we are at a[0], but
                     // this avoids possible over/under flows of tracking variables)
@@ -973,8 +994,6 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
                 if res_acc_left != 0 {
                     BE::znx_normalize_middle_step_assign(res_base2k, 0, res_slice, res_carry);
                 }
-
-                finish_normalized_limb(res_base2k, active_size, padding, res_limb, res_slice, res_carry);
 
                 if res_limb == 0 {
                     break 'outer;
@@ -1014,7 +1033,6 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
 
         for j in (0..res_end).rev() {
             BE::znx_extract_digit_mul(res_base2k, 0, res.at_mut(j), carry_to_use);
-            finish_normalized_limb(res_base2k, active_size, padding, j, res.at_mut(j), carry_to_use);
         }
     }
 }
@@ -1026,7 +1044,11 @@ pub fn vec_znx_normalize_assign<'r, BE>(
     res_col: usize,
     carry: &mut [i64],
 ) where
-    BE: Backend<ZnxWord = i64> + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
+    BE: Backend<ZnxWord = i64>
+        + I64NormalizeOps
+        + ZnxNormalizeFirstStepAssign
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxNormalizeFinalStepAssign,
     BE::BufMut<'r>: HostDataMut,
 {
     assert!(res_k <= res.size() * base2k);
@@ -1044,7 +1066,11 @@ fn vec_znx_normalize_assign_range<'r, BE>(
     coeff_len: usize,
     carry: &mut [i64],
 ) where
-    BE: Backend<ZnxWord = i64> + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
+    BE: Backend<ZnxWord = i64>
+        + I64NormalizeOps
+        + ZnxNormalizeFirstStepAssign
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxNormalizeFinalStepAssign,
     BE::BufMut<'r>: HostDataMut,
 {
     #[cfg(debug_assertions)]
@@ -1084,7 +1110,11 @@ pub unsafe fn vec_znx_normalize_assign_range_raw<BE>(
     coeff_len: usize,
     carry: &mut [i64],
 ) where
-    BE: Backend<ZnxWord = i64> + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
+    BE: Backend<ZnxWord = i64>
+        + I64NormalizeOps
+        + ZnxNormalizeFirstStepAssign
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxNormalizeFinalStepAssign,
 {
     #[cfg(debug_assertions)]
     {
@@ -1095,17 +1125,49 @@ pub unsafe fn vec_znx_normalize_assign_range_raw<BE>(
     }
     let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
     let carry = &mut carry[..coeff_len];
-    let active_size = res_k.div_ceil(base2k);
-    let padding = (base2k - res_k % base2k) % base2k;
+    if res_k == 0 {
+        for j in 0..size {
+            res.at_mut(j).fill(0);
+        }
+        return;
+    }
     if base2k == 64 {
-        carry.fill(0);
-        for j in (0..size).rev() {
-            for (digit, carry) in res.at_mut(j).iter_mut().zip(carry.iter_mut()) {
-                let (value, next) = split_digit(base2k, *digit as i128 + *carry as i128);
-                *digit = value;
-                *carry = next as i64;
+        for i in 0..coeff_len {
+            normalize_exact::<true, _, _>(
+                |j| unsafe { *res_ptr.add((j * cols + res_col) * n + coeff_start + i) } as i128,
+                size,
+                base2k,
+                size,
+                base2k,
+                res_k,
+                0,
+                |j, digit| res.at_mut(j)[i] = digit,
+            );
+        }
+        return;
+    }
+    let active_size = res_k.div_ceil(base2k);
+    if res_k != size * base2k {
+        let padding = active_size * base2k - res_k;
+        let discarded = active_size < size;
+        for j in (active_size..size).rev() {
+            match (j + 1 == size, padding == 0 && j == active_size) {
+                (true, false) => BE::znx_normalize_floor::<false, false>(base2k, 0, res.at_mut(j), carry),
+                (true, true) => BE::znx_normalize_floor::<false, true>(base2k, 0, res.at_mut(j), carry),
+                (false, false) => BE::znx_normalize_floor::<true, false>(base2k, 0, res.at_mut(j), carry),
+                (false, true) => BE::znx_normalize_floor::<true, true>(base2k, 0, res.at_mut(j), carry),
             }
-            finish_normalized_limb(base2k, active_size, padding, j, res.at_mut(j), carry);
+        }
+        if discarded {
+            BE::znx_normalize_round_assign::<true>(base2k, 0, padding, res.at_mut(active_size - 1), carry);
+        } else {
+            BE::znx_normalize_round_assign::<false>(base2k, 0, padding, res.at_mut(active_size - 1), carry);
+        }
+        for j in (0..active_size - 1).rev() {
+            BE::znx_normalize_middle_step_assign(base2k, 0, res.at_mut(j), carry);
+        }
+        for j in active_size..size {
+            res.at_mut(j).fill(0);
         }
         return;
     }
@@ -1117,7 +1179,6 @@ pub unsafe fn vec_znx_normalize_assign_range_raw<BE>(
         } else {
             BE::znx_normalize_middle_step_assign(base2k, 0, res.at_mut(j), carry);
         }
-        finish_normalized_limb(base2k, active_size, padding, j, res.at_mut(j), carry);
     }
 }
 
@@ -1653,7 +1714,7 @@ impl<F: FnMut(usize) -> i128, const NARROW: bool> NormalizationBits<F, NARROW> {
     }
 }
 
-/// Quantizes at the destination capacity, then emits canonical digits at `res_k`.
+/// Quantizes once at `res_k`, then emits centered digits with zero precision padding.
 /// `NARROW` requires every source coefficient to fit in i64.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn normalize_exact<const NARROW: bool, F: FnMut(usize) -> i128, G: FnMut(usize, i64)>(
@@ -1666,30 +1727,18 @@ pub(crate) fn normalize_exact<const NARROW: bool, F: FnMut(usize) -> i128, G: Fn
     offset: i64,
     mut output: G,
 ) {
-    let active_size = res_k.div_ceil(res_base2k);
-    let precision_padding = (res_base2k - res_k % res_base2k) % res_base2k;
-    let mut precision_carry = 0i128;
-    let mut output = |j, digit: i64| {
-        if j >= active_size {
-            output(j, 0);
-        } else if res_k == res_size * res_base2k {
-            output(j, digit);
-        } else {
-            let mut value = digit as i128 + precision_carry;
-            if j + 1 == active_size && precision_padding != 0 {
-                value -= split_digit(precision_padding, value).0 as i128;
-            }
-            let (digit, carry) = split_digit(res_base2k, value);
-            precision_carry = carry;
-            output(j, digit);
-        }
-    };
     if a_base2k > 63 || res_base2k > 63 {
-        normalize_exact_wide(source, a_size, a_base2k, res_size, res_base2k, offset, output);
+        normalize_exact_wide(source, a_size, a_base2k, res_size, res_base2k, res_k, offset, output);
         return;
     }
+    let (active_size, precision_padding) = if res_k == res_size * res_base2k {
+        (res_size, 0)
+    } else {
+        let active_size = res_k.div_ceil(res_base2k);
+        (active_size, active_size * res_base2k - res_k)
+    };
     let mut bits = NormalizationBits::<_, NARROW>::new(source, a_size, a_base2k);
-    let drop = a_size as i128 * a_base2k as i128 - res_size as i128 * res_base2k as i128 - offset as i128;
+    let drop = a_size as i128 * a_base2k as i128 - res_k as i128 - offset as i128;
     let mut carry = 0u64;
     let mut padding = 0i128;
     if drop > 0 {
@@ -1698,8 +1747,22 @@ pub(crate) fn normalize_exact<const NARROW: bool, F: FnMut(usize) -> i128, G: Fn
     } else {
         padding = -drop;
     }
+    let mut full_size = active_size;
+    if precision_padding != 0 {
+        full_size -= 1;
+        let width = res_base2k - precision_padding;
+        let zeroes = padding.min(width as i128) as usize;
+        padding -= zeroes as i128;
+        let raw = bits.read(width - zeroes) << zeroes;
+        let value = raw + carry;
+        carry = (value + (1u64 << (width - 1))) >> width;
+        output(
+            full_size,
+            ((value as i128 - ((carry as i128) << width)) << precision_padding) as i64,
+        );
+    }
     let half = 1u64 << (res_base2k - 1);
-    for j in (0..res_size).rev() {
+    for j in (0..full_size).rev() {
         let zeroes = padding.min(res_base2k as i128) as usize;
         padding -= zeroes as i128;
         let raw = bits.read(res_base2k - zeroes) << zeroes;
@@ -1707,20 +1770,31 @@ pub(crate) fn normalize_exact<const NARROW: bool, F: FnMut(usize) -> i128, G: Fn
         carry = (value + half) >> res_base2k;
         output(j, (value as i128 - ((carry as i128) << res_base2k)) as i64);
     }
+    for j in active_size..res_size {
+        output(j, 0);
+    }
 }
 
 // Preserves the wider source radices and base-64 output supported by NTT.
+#[allow(clippy::too_many_arguments)]
 fn normalize_exact_wide<F: FnMut(usize) -> i128, G: FnMut(usize, i64)>(
     mut source: F,
     a_size: usize,
     a_base2k: usize,
     res_size: usize,
     res_base2k: usize,
+    res_k: usize,
     offset: i64,
     mut output: G,
 ) {
     assert!((1..=127).contains(&a_base2k));
     assert!((1..=64).contains(&res_base2k));
+    let (active_size, precision_padding) = if res_k == res_size * res_base2k {
+        (res_size, 0)
+    } else {
+        let active_size = res_k.div_ceil(res_base2k);
+        (active_size, active_size * res_base2k - res_k)
+    };
     let mask = (1u128 << a_base2k) - 1;
     let mut left = a_size;
     let mut carry = 0i128;
@@ -1757,7 +1831,7 @@ fn normalize_exact_wide<F: FnMut(usize) -> i128, G: FnMut(usize, i64)>(
         }
         result
     };
-    let drop = a_size as i128 * a_base2k as i128 - res_size as i128 * res_base2k as i128 - offset as i128;
+    let drop = a_size as i128 * a_base2k as i128 - res_k as i128 - offset as i128;
     let mut rounding = 0u128;
     let mut padding = 0i128;
     if drop > 0 {
@@ -1766,13 +1840,29 @@ fn normalize_exact_wide<F: FnMut(usize) -> i128, G: FnMut(usize, i64)>(
     } else {
         padding = -drop;
     }
+    let mut full_size = active_size;
+    if precision_padding != 0 {
+        full_size -= 1;
+        let width = res_base2k - precision_padding;
+        let zeroes = padding.min(width as i128) as usize;
+        padding -= zeroes as i128;
+        let value = (read((width - zeroes) as i128, false) << zeroes) + rounding;
+        rounding = (value + (1u128 << (width - 1))) >> width;
+        output(
+            full_size,
+            ((value as i128 - ((rounding as i128) << width)) << precision_padding) as i64,
+        );
+    }
     let half = 1u128 << (res_base2k - 1);
-    for j in (0..res_size).rev() {
+    for j in (0..full_size).rev() {
         let zeroes = padding.min(res_base2k as i128) as usize;
         padding -= zeroes as i128;
         let value = (read((res_base2k - zeroes) as i128, false) << zeroes) + rounding;
         rounding = (value + half) >> res_base2k;
         output(j, (value as i128 - ((rounding as i128) << res_base2k)) as i64);
+    }
+    for j in active_size..res_size {
+        output(j, 0);
     }
 }
 

--- a/poulpy-cpu-ref/src/test_suite/normalization.rs
+++ b/poulpy-cpu-ref/src/test_suite/normalization.rs
@@ -21,6 +21,7 @@ where
         + I64NormalizeOps
         + ZnxNormalizeDigit,
 {
+    test_boundary_kernels::<B>();
     let steps: [(Step, Step); 8] = [
         (znx_normalize_first_step_ref::<true>, B::znx_normalize_first_step::<true>),
         (znx_normalize_first_step_ref::<false>, B::znx_normalize_first_step::<false>),
@@ -171,6 +172,79 @@ where
                 znx_normalize_digit_ref(k, &mut r, &mut rs);
                 B::znx_normalize_digit(k, &mut b, &mut bs);
                 assert_eq!((&r, &rs), (&b, &bs), "digit k={k}, lsh={lsh}, n={n}");
+            }
+        }
+    }
+}
+
+fn test_boundary_kernels<B: I64NormalizeOps>() {
+    fn check<B: I64NormalizeOps, const INPUT: bool, const MODE: bool>(k: usize, lsh: usize, padding: usize, n: usize) {
+        use crate::reference::normalization::{znx_normalize_floor_ref, znx_normalize_round_assign_ref, znx_normalize_round_ref};
+        let mut state = 0x1234_5678_abcd_ef90u64;
+        let half = 1i64 << (k - 1);
+        let edge = [-(1i64 << 62), 1i64 << 62, -half, half, half - 1, -half + 1, -1, 0, 1];
+        let a: Vec<_> = (0..n + 2)
+            .map(|i| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                if i > 0 && i <= edge.len() {
+                    edge[(i - 1 + lsh) % edge.len()]
+                } else {
+                    state as i64 >> 1
+                }
+            })
+            .collect();
+        let carry: Vec<_> = (0..n + 2).map(|i| edge[(i + padding) % edge.len()]).collect();
+        let (mut got, mut want) = (carry.clone(), carry.clone());
+        znx_normalize_floor_ref::<INPUT, MODE>(k, lsh, &a[1..], &mut want[1..n + 1]);
+        B::znx_normalize_floor::<INPUT, MODE>(k, lsh, &a[1..], &mut got[1..n + 1]);
+        assert_eq!(got, want, "floor k={k} lsh={lsh} n={n} input={INPUT} guard={MODE}");
+        for i in 1..n + 1 {
+            let value = ((a[i] as i128) << lsh) + if INPUT { carry[i] as i128 } else { 0 };
+            assert_eq!(got[i] as i128, (value + if MODE { 1i128 << (k - 1) } else { 0 }) >> k);
+        }
+        let (mut got_c, mut want_c) = (carry.clone(), carry.clone());
+        let (mut got_r, mut want_r) = (a.clone(), a.clone());
+        znx_normalize_round_ref::<INPUT, MODE>(k, lsh, padding, &mut want_r[1..n + 1], &a[1..], &mut want_c[1..]);
+        B::znx_normalize_round::<INPUT, MODE>(k, lsh, padding, &mut got_r[1..n + 1], &a[1..], &mut got_c[1..]);
+        assert_eq!(
+            (&got_r, &got_c),
+            (&want_r, &want_c),
+            "round k={k} lsh={lsh} padding={padding} n={n} input={INPUT} pad={MODE}"
+        );
+        for i in 1..n + 1 {
+            let value = ((a[i] as i128) << lsh) + if INPUT { carry[i] as i128 } else { 0 };
+            let rounded = (value + if padding == 0 { 0 } else { 1i128 << (padding - 1) }) >> padding;
+            let width = k - padding;
+            let high = (rounded + (1i128 << (width - 1))) >> width;
+            let digit = rounded - (high << width);
+            assert_eq!(got_c[i] as i128, high);
+            assert_eq!(got_r[i] as i128, digit << if MODE { padding } else { 0 });
+        }
+        if MODE {
+            let (mut got_c, mut want_c) = (carry.clone(), carry);
+            let (mut got_r, mut want_r) = (a.clone(), a);
+            znx_normalize_round_assign_ref::<INPUT>(k, lsh, padding, &mut want_r[1..n + 1], &mut want_c[1..]);
+            B::znx_normalize_round_assign::<INPUT>(k, lsh, padding, &mut got_r[1..n + 1], &mut got_c[1..]);
+            assert_eq!(
+                (got_r, got_c),
+                (want_r, want_c),
+                "round assign k={k} lsh={lsh} padding={padding} n={n}"
+            );
+        }
+    }
+    for k in 1..=63 {
+        for lsh in 0..k {
+            let mut paddings = vec![0, k / 2, k - 1];
+            paddings.dedup();
+            for padding in paddings {
+                for n in [0, 1, 3, 7, 8, 9, 17] {
+                    check::<B, false, false>(k, lsh, padding, n);
+                    check::<B, false, true>(k, lsh, padding, n);
+                    check::<B, true, false>(k, lsh, padding, n);
+                    check::<B, true, true>(k, lsh, padding, n);
+                }
             }
         }
     }

--- a/poulpy-cpu-ref/src/test_suite/normalization_i128.rs
+++ b/poulpy-cpu-ref/src/test_suite/normalization_i128.rs
@@ -5,6 +5,7 @@ use crate::reference::ntt4x30::I128NormalizeOps;
 use crate::reference::znx::{get_digit_i64, znx_extract_digit_addmul_normalize_i128_ref};
 
 pub fn test_i128_normalize_fused<BE: I128NormalizeOps>() {
+    test_boundary_kernels::<BE>();
     let idft_bound = (1_073_479_681i128 * 1_071_513_601 * 1_070_727_169 * 1_068_236_801 - 1) / 2;
     for res_base2k in 1..=63 {
         for base2k in 1..=res_base2k {
@@ -82,6 +83,84 @@ pub fn test_i128_normalize_fused<BE: I128NormalizeOps>() {
             crate::reference::znx::znx_extract_digit_mul_i128_ref(base2k, scale, &mut want_res, &mut want_input);
             BE::znx_extract_digit_mul_i128(base2k, scale, &mut res, &mut input);
             assert_eq!((&res, &input), (&want_res, &want_input));
+        }
+    }
+}
+
+fn test_boundary_kernels<B: I128NormalizeOps>() {
+    fn check<B: I128NormalizeOps, const INPUT: bool, const MODE: bool>(k: usize, lsh: usize, padding: usize, n: usize) {
+        use crate::reference::normalization::{
+            nfc_normalize_floor_ref, nfc_normalize_round_ref, znx_extract_digit_addmul_i128_ref,
+        };
+        let idft_bound = (1_073_479_681i128 * 1_071_513_601 * 1_070_727_169 * 1_068_236_801 - 1) / 2;
+        let half = 1i128 << (k - 1);
+        let edge = [
+            -(1i128 << 126),
+            1i128 << 126,
+            -idft_bound,
+            idft_bound,
+            -half,
+            half,
+            half - 1,
+            -half + 1,
+            -1,
+            0,
+            1,
+        ];
+        let mut state = 0x1234_5678_abcd_ef90u128;
+        let a: Vec<_> = (0..n + 2)
+            .map(|i| {
+                state ^= state << 17;
+                state ^= state >> 29;
+                state ^= state << 43;
+                if i > 0 && i <= edge.len() {
+                    edge[(i - 1 + lsh) % edge.len()]
+                } else {
+                    state as i128 >> 1
+                }
+            })
+            .collect();
+        let carry: Vec<_> = (0..n + 2).map(|i| edge[(i + padding) % edge.len()]).collect();
+        let (mut got, mut want) = (carry.clone(), carry.clone());
+        nfc_normalize_floor_ref::<INPUT, MODE>(k, lsh, &a[1..], &mut want[1..n + 1]);
+        B::nfc_normalize_floor::<INPUT, MODE>(k, lsh, &a[1..], &mut got[1..n + 1]);
+        assert_eq!(got, want, "wide floor k={k} lsh={lsh} n={n} input={INPUT} guard={MODE}");
+        let output: Vec<_> = a.iter().map(|&v| v as i64).collect();
+        let (mut got_c, mut want_c) = (carry.clone(), carry.clone());
+        let (mut got_r, mut want_r) = (output.clone(), output.clone());
+        nfc_normalize_round_ref::<INPUT, MODE>(k, lsh, padding, &mut want_r[1..n + 1], &a[1..], &mut want_c[1..]);
+        B::nfc_normalize_round::<INPUT, MODE>(k, lsh, padding, &mut got_r[1..n + 1], &a[1..], &mut got_c[1..]);
+        assert_eq!(
+            (got_r, got_c),
+            (want_r, want_c),
+            "wide round k={k} lsh={lsh} padding={padding} n={n} input={INPUT} pad={MODE}"
+        );
+        if INPUT && MODE {
+            let (mut got, mut want) = (carry.clone(), carry);
+            for (out, &v) in want[1..n + 1].iter_mut().zip(&output[1..]) {
+                *out += v as i128;
+            }
+            B::nfc_add_small_carry(&mut got[1..n + 1], &output[1..]);
+            assert_eq!(got, want);
+            let (mut got_r, mut want_r) = (output.clone(), output);
+            let (mut got_a, mut want_a) = (a.clone(), a);
+            znx_extract_digit_addmul_i128_ref(k, 63 - k, &mut want_r[1..n + 1], &mut want_a[1..]);
+            B::znx_extract_digit_addmul_i128(k, 63 - k, &mut got_r[1..n + 1], &mut got_a[1..]);
+            assert_eq!((got_r, got_a), (want_r, want_a), "wide tail k={k} n={n}");
+        }
+    }
+    for k in 1..=63 {
+        for lsh in 0..k {
+            let mut paddings = vec![0, k / 2, k - 1];
+            paddings.dedup();
+            for padding in paddings {
+                for n in [0, 1, 3, 7, 8, 9, 17] {
+                    check::<B, false, false>(k, lsh, padding, n);
+                    check::<B, false, true>(k, lsh, padding, n);
+                    check::<B, true, false>(k, lsh, padding, n);
+                    check::<B, true, true>(k, lsh, padding, n);
+                }
+            }
         }
     }
 }

--- a/poulpy-cpu-ref/src/tests.rs
+++ b/poulpy-cpu-ref/src/tests.rs
@@ -532,7 +532,7 @@ fn test_normalize_exact_canonical_precision() {
     let cases: &[Case<'_>] = &[
         (&[3, 7, 5, 0], 4, 4, 6, 0, &[4, -8]),
         (&[-3, -7, -5, 0], 4, 4, 6, 0, &[-3, -8]),
-        (&[3, 7, 7], 5, 4, 6, 0, &[2, -4]),
+        (&[3, 7, 7], 5, 4, 6, 0, &[2, -8]),
         (&[3, 7, 7], 5, 4, 4, 0, &[2, 0]),
         (&[3, 7, 7], 5, 4, 0, 0, &[0, 0]),
         (&[1400], 4, 4, 14, -20, &[0, 0, 0, 4]),
@@ -847,6 +847,293 @@ fn test_vec_znx_big_normalize_wide_radices() {
                         let want = normalize_integer_oracle(&limbs, a_base2k, res_base2k, size, offset);
                         let got: Vec<_> = (0..size).map(|j| output.at(0, j)[i]).collect();
                         assert_eq!(got, want, "ka={a_base2k} kr={res_base2k} size={size} offset={offset}");
+                    }
+                }
+            }
+        }
+    }
+}
+mod canonical_precision_tests {
+    use crate::{
+        FFT64Ref, NTT4x30Ref,
+        reference::{
+            ntt4x30::{ntt4x30_vec_znx_big_normalize, ntt4x30_vec_znx_big_normalize_range_raw},
+            vec_znx::{
+                vec_znx_normalize, vec_znx_normalize_assign, vec_znx_normalize_assign_range_raw, vec_znx_normalize_range_raw,
+            },
+        },
+    };
+    use dashu_int::IBig;
+    use poulpy_hal::layouts::{VecZnx, VecZnxBig, VecZnxToBackendMut, VecZnxToBackendRef, ZnxView, ZnxViewMut};
+
+    const N: usize = 9;
+    const IDFT_BOUND: i128 = (1_073_479_681i128 * 1_071_513_601 * 1_070_727_169 * 1_068_236_801 - 1) / 2;
+
+    // One rounding decision on the exact integer value, independent of limb scheduling.
+    fn oracle(a: &[i128], ka: usize, kr: usize, k: usize, size: usize, offset: i64) -> Vec<i64> {
+        let mut result = vec![0; size];
+        let shift = k as i128 + offset as i128 - (a.len() * ka) as i128;
+        if k == 0 || offset as i128 >= (a.len() * ka) as i128 || shift < -((a.len() * ka + 130) as i128) {
+            return result;
+        }
+        let mut value = a.iter().fold(IBig::ZERO, |sum, &limb| (sum << ka) + IBig::from(limb));
+        if shift >= 0 {
+            value <<= shift as usize;
+        } else {
+            let drop = (-shift) as usize;
+            value = (value + (IBig::ONE << (drop - 1))) >> drop;
+        }
+        value <<= size * kr - k;
+        for digit in result.iter_mut().rev() {
+            let carry = (&value + (IBig::ONE << (kr - 1))) >> kr;
+            *digit = i64::try_from(&value - (&carry << kr)).unwrap();
+            value = carry;
+        }
+        result
+    }
+
+    fn small(size: usize) -> VecZnx<Vec<u8>, i64> {
+        VecZnx::from_data(vec![0xa5; 8 * N * 2 * size], N, 2, size)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn check(a: &[Vec<i128>], ka: usize, kr: usize, k: usize, size: usize, offset: i64, ranges: bool) {
+        let mut input = small(a.len());
+        let mut wide = VecZnxBig::<Vec<u8>, i128, NTT4x30Ref>::from_data(vec![0; 16 * N * 2 * a.len()], N, 2, a.len());
+        for (j, values) in a.iter().enumerate() {
+            for (i, &value) in values.iter().enumerate() {
+                input.at_mut(1, j)[i] = value as i64;
+                wide.at_mut(1, j)[i] = value;
+            }
+        }
+        let narrow = ka <= 62 && kr <= 62 && a.iter().flatten().all(|&x| (-(1i128 << 62)..=1i128 << 62).contains(&x));
+        let expected: Vec<_> = (0..N)
+            .map(|i| oracle(&a.iter().map(|v| v[i]).collect::<Vec<_>>(), ka, kr, k, size, offset))
+            .collect();
+        let verify = |name: &str, output: &VecZnx<Vec<u8>, i64>| {
+            for (i, want) in expected.iter().enumerate() {
+                let got: Vec<_> = (0..size).map(|j| output.at(1, j)[i]).collect();
+                assert_eq!(
+                    got, *want,
+                    "{name}: ka={ka} kr={kr} k={k} size={size} offset={offset} i={i} a={a:?}"
+                );
+            }
+            for j in 0..size {
+                assert!(output.at(0, j).iter().all(|&x| x == i64::from_ne_bytes([0xa5; 8])));
+            }
+        };
+        let mut output = small(size);
+        if narrow {
+            let src = <VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&input);
+            if ranges {
+                let ptr = output.data_mut().as_mut_ptr().cast::<i64>();
+                for (start, len) in [(0, 2), (2, 3), (5, 4)] {
+                    unsafe {
+                        vec_znx_normalize_range_raw::<FFT64Ref>(
+                            ptr,
+                            N,
+                            2,
+                            size,
+                            kr,
+                            k,
+                            offset,
+                            1,
+                            &src,
+                            ka,
+                            1,
+                            start,
+                            len,
+                            &mut vec![73; 3 * len],
+                        );
+                    }
+                }
+            } else {
+                vec_znx_normalize::<FFT64Ref>(
+                    &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut output),
+                    kr,
+                    k,
+                    offset,
+                    1,
+                    &src,
+                    ka,
+                    1,
+                    &mut [73; 3 * N],
+                );
+            }
+            verify("narrow", &output);
+        }
+        output = small(size);
+        if ranges {
+            let ptr = output.data_mut().as_mut_ptr().cast::<i64>();
+            for (start, len) in [(0, 2), (2, 3), (5, 4)] {
+                unsafe {
+                    ntt4x30_vec_znx_big_normalize_range_raw::<_, NTT4x30Ref>(
+                        ptr,
+                        N,
+                        2,
+                        size,
+                        kr,
+                        k,
+                        offset,
+                        1,
+                        &wide,
+                        ka,
+                        1,
+                        start,
+                        len,
+                        &mut vec![73; 3 * len],
+                    );
+                }
+            }
+        } else {
+            ntt4x30_vec_znx_big_normalize::<_, _, NTT4x30Ref>(&mut output, kr, k, offset, 1, &wide, ka, 1, &mut [73; 3 * N]);
+        }
+        verify("wide", &output);
+        if narrow && ka == kr && size == a.len() && offset == 0 {
+            if ranges {
+                let ptr = input.data_mut().as_mut_ptr().cast::<i64>();
+                for (start, len) in [(0, 2), (2, 3), (5, 4)] {
+                    unsafe {
+                        vec_znx_normalize_assign_range_raw::<FFT64Ref>(ptr, N, 2, size, kr, k, 1, start, len, &mut vec![73; len]);
+                    }
+                }
+            } else {
+                vec_znx_normalize_assign::<FFT64Ref>(
+                    kr,
+                    k,
+                    &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut input),
+                    1,
+                    &mut [73; N],
+                );
+            }
+            verify("assign", &input);
+        }
+    }
+
+    #[test]
+    fn test_canonical_precision_round_once_regressions() {
+        for (a, ka, kr, k, size) in [
+            (vec![1, -8], 4, 4, 3, 1),
+            (vec![0, 1, 2], 2, 3, 2, 1),
+            (vec![1, -8, -8], 4, 4, 4, 3),
+            (vec![1, -8, -8], 4, 4, 4, 1),
+            (vec![1, -(1i128 << 49)], 50, 50, 49, 1),
+        ] {
+            for sign in [-1, 1] {
+                check(
+                    &a.iter().map(|&x| vec![sign * x; N]).collect::<Vec<_>>(),
+                    ka,
+                    kr,
+                    k,
+                    size,
+                    0,
+                    false,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_canonical_precision_integer_oracle() {
+        for ka in [1, 2, 17, 19, 21, 50, 51, 62] {
+            for kr in [1, 2, 17, 19, 21, 50, 51, 62] {
+                for a_size in [1, 3] {
+                    let half = 1i128 << (ka - 1);
+                    let digits = [0, 1, -1, 1i128 << 62, -(1i128 << 62), half, -half, half - 1, -half - 1];
+                    let input: Vec<Vec<_>> = (0..a_size)
+                        .map(|j| (0..N).map(|i| digits[(i + 2 * j) % N]).collect())
+                        .collect();
+                    for size in [1, 3] {
+                        let mut precisions = vec![0, 1, kr - 1, kr, size * kr / 2, size * kr - 1, size * kr];
+                        precisions.sort_unstable();
+                        precisions.dedup();
+                        for k in precisions {
+                            for offset in [-(ka as i64), -1, 0, 1, ka as i64, i64::MIN, i64::MAX] {
+                                check(&input, ka, kr, k, size, offset, k.is_multiple_of(2));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_canonical_precision_cross_boundaries() {
+        for (ka, kr) in [(1, 2), (2, 1), (17, 50), (50, 17), (50, 51), (51, 50), (51, 62), (62, 51)] {
+            let digits = [
+                0,
+                1,
+                -1,
+                1i128 << 62,
+                -(1i128 << 62),
+                (1i128 << 62) - 1,
+                -(1i128 << 62) + 1,
+                7,
+                -7,
+            ];
+            let input: Vec<Vec<_>> = (0..8).map(|j| (0..N).map(|i| digits[(i + 2 * j) % N]).collect()).collect();
+            // Every width of the last active limb, including the 50 -> 51 dispatch boundary at k=399/400.
+            let mut precisions: Vec<_> = (7 * kr + 1..=8 * kr).chain([1, kr - 1, kr, 4 * kr]).collect();
+            precisions.sort_unstable();
+            precisions.dedup();
+            for k in precisions {
+                for offset in [-(ka as i64) - 1, -1, 0, 1, ka as i64 + 1] {
+                    for size in [8, 9] {
+                        check(&input, ka, kr, k, size, offset, k.is_multiple_of(2));
+                    }
+                    let drop = 8 * ka as i64 - k as i64 - offset;
+                    if !(1..8 * ka as i64).contains(&drop) {
+                        continue;
+                    }
+                    // Encode exact values immediately below, at and above both signed rounding ties.
+                    let half = IBig::ONE << (drop as usize - 1);
+                    let mut ties = vec![vec![0; N]; 8];
+                    let mut values: Vec<_> = (0..N).map(|i| &half * (i / 3) as i32 - &half + (i % 3) as i32 - 1).collect();
+                    for limb in ties[1..].iter_mut().rev() {
+                        for (digit, value) in limb.iter_mut().zip(values.iter_mut()) {
+                            let carry = &*value >> ka;
+                            *digit = i128::try_from(&*value - (&carry << ka)).unwrap();
+                            *value = carry;
+                        }
+                    }
+                    for (digit, value) in ties[0].iter_mut().zip(values) {
+                        *digit = i128::try_from(value).unwrap();
+                    }
+                    check(&ties, ka, kr, k, 9, offset, !k.is_multiple_of(2));
+                }
+            }
+            let wide_digits = [IDFT_BOUND, -IDFT_BOUND, i64::MAX as i128, i64::MIN as i128, 0, 1, -1, 7, -7];
+            let wide: Vec<Vec<_>> = (0..8)
+                .map(|j| (0..N).map(|i| wide_digits[(i + 2 * j) % N]).collect())
+                .collect();
+            for k in [1, kr, 4 * kr, 8 * kr - 1, 8 * kr] {
+                for offset in [-(ka as i64) - 1, 0, ka as i64 + 1] {
+                    check(&wide, ka, kr, k, 9, offset, k.is_multiple_of(2));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_canonical_precision_wide_integer_oracle() {
+        for ka in [1, 17, 50, 62, 63, 64, 119, 127] {
+            for kr in [1, 19, 51, 62, 63, 64] {
+                let digits = [
+                    IDFT_BOUND,
+                    -IDFT_BOUND,
+                    i64::MAX as i128,
+                    i64::MIN as i128,
+                    0,
+                    1,
+                    -1,
+                    (1i128 << 100) + 1,
+                    -(1i128 << 100) - 1,
+                ];
+                let input: Vec<Vec<_>> = (0..3).map(|j| (0..N).map(|i| digits[(i + 2 * j) % N]).collect()).collect();
+                for k in [0, 1, kr - 1, kr, 2 * kr + 1, 3 * kr] {
+                    for offset in [-(ka as i64) - 1, 0, 1, ka as i64 + 1] {
+                        check(&input, ka, kr, k, 3, offset, k.is_multiple_of(2));
                     }
                 }
             }

--- a/poulpy-hal/src/test_suite/vec_znx.rs
+++ b/poulpy-hal/src/test_suite/vec_znx.rs
@@ -46,6 +46,23 @@ fn assert_canonical(a: &VecZnx<impl HostDataRef, i64>, base2k: usize, k: usize) 
     }
 }
 
+pub(super) fn cross_normalization_cases(a_size: usize, res_size: usize) -> Vec<(usize, usize, usize, i64)> {
+    let mut cases = Vec::new();
+    if matches!(a_size, 1 | 4) && matches!(res_size, 1 | 4) {
+        for (a_base, res_base) in [(1, 2), (2, 1), (17, 50), (50, 17), (50, 51), (51, 50), (51, 62), (62, 51)] {
+            for k in [
+                res_size * res_base - res_base / 2 - 1,
+                res_size.saturating_sub(1).max(1) * res_base - 1,
+            ] {
+                for offset in [-(a_base as i64) - 1, 0, a_base as i64 + 1] {
+                    cases.push((a_base, res_base, k, offset));
+                }
+            }
+        }
+    }
+    cases
+}
+
 pub fn test_vec_znx_zero_backend_matches_wrapper<BR: crate::test_suite::TestBackend, BT: crate::test_suite::TestBackend>(
     params: &TestParams,
     module_host: &Module<HostBytesBackend>,
@@ -1442,37 +1459,43 @@ pub fn test_vec_znx_normalize<BR: crate::test_suite::TestBackend, BT: crate::tes
                 );
             }
 
-            let res_k = res_size.saturating_sub(1).max(1) * base2k - 1;
-            let mut res_ref_backend = upload_vec_znx::<BR>(&res_ref);
-            let mut res_test_backend = upload_vec_znx::<BT>(&res_test);
-            for i in 0..cols {
-                module_ref.vec_znx_normalize(
-                    &mut vec_znx_backend_mut::<BR>(&mut res_ref_backend),
-                    base2k,
-                    res_k,
-                    0,
-                    i,
-                    &vec_znx_backend_ref::<BR>(&a_ref),
-                    base2k,
-                    i,
-                    &mut scratch_ref.arena(),
+            let same_base = (base2k, base2k, res_size.saturating_sub(1).max(1) * base2k - 1, 0);
+            for (a_base, res_base, res_k, offset) in std::iter::once(same_base).chain(cross_normalization_cases(a_size, res_size))
+            {
+                let mut res_ref_backend = upload_vec_znx::<BR>(&res_ref);
+                let mut res_test_backend = upload_vec_znx::<BT>(&res_test);
+                for i in 0..cols {
+                    module_ref.vec_znx_normalize(
+                        &mut vec_znx_backend_mut::<BR>(&mut res_ref_backend),
+                        res_base,
+                        res_k,
+                        offset,
+                        i,
+                        &vec_znx_backend_ref::<BR>(&a_ref),
+                        a_base,
+                        i,
+                        &mut scratch_ref.arena(),
+                    );
+                    module_test.vec_znx_normalize(
+                        &mut vec_znx_backend_mut::<BT>(&mut res_test_backend),
+                        res_base,
+                        res_k,
+                        offset,
+                        i,
+                        &vec_znx_backend_ref::<BT>(&a_test),
+                        a_base,
+                        i,
+                        &mut scratch_test.arena(),
+                    );
+                }
+                let res_ref_host = download_vec_znx::<BR>(&res_ref_backend);
+                let res_test_host = download_vec_znx::<BT>(&res_test_backend);
+                assert_eq!(
+                    res_ref_host, res_test_host,
+                    "a_base={a_base} res_base={res_base} k={res_k} offset={offset}"
                 );
-                module_test.vec_znx_normalize(
-                    &mut vec_znx_backend_mut::<BT>(&mut res_test_backend),
-                    base2k,
-                    res_k,
-                    0,
-                    i,
-                    &vec_znx_backend_ref::<BT>(&a_test),
-                    base2k,
-                    i,
-                    &mut scratch_test.arena(),
-                );
+                assert_canonical(&res_test_host, res_base, res_k);
             }
-            let res_ref_host = download_vec_znx::<BR>(&res_ref_backend);
-            let res_test_host = download_vec_znx::<BT>(&res_test_backend);
-            assert_eq!(res_ref_host, res_test_host);
-            assert_canonical(&res_test_host, base2k, res_k);
         }
     }
 }

--- a/poulpy-hal/src/test_suite/vec_znx_big.rs
+++ b/poulpy-hal/src/test_suite/vec_znx_big.rs
@@ -74,12 +74,20 @@ where
     BE: crate::test_suite::TestBackend,
     Module<BE>: VecZnxBigNormalize<BE>,
 {
-    normalize_big_to_host_with_precision(module, base2k, res_size * base2k, res_offset, res_size, backend, scratch)
+    normalize_big_to_host_with_precision(
+        module,
+        (base2k, base2k),
+        res_size * base2k,
+        res_offset,
+        res_size,
+        backend,
+        scratch,
+    )
 }
 
 fn normalize_big_to_host_with_precision<BE>(
     module: &Module<BE>,
-    base2k: usize,
+    base2k: (usize, usize),
     res_k: usize,
     res_offset: i64,
     res_size: usize,
@@ -90,17 +98,18 @@ where
     BE: crate::test_suite::TestBackend,
     Module<BE>: VecZnxBigNormalize<BE>,
 {
+    let (a_base2k, res_base2k) = base2k;
     let shape = backend.shape();
     let mut res_backend = module.vec_znx_alloc(shape.cols(), res_size);
     for j in 0..shape.cols() {
         module.vec_znx_big_normalize(
             &mut <VecZnx<BE::OwnedBuf, BE::ZnxWord> as VecZnxToBackendMut<BE>>::to_backend_mut(&mut res_backend),
-            base2k,
+            res_base2k,
             res_k,
             res_offset,
             j,
             &backend.to_backend_ref(),
-            base2k,
+            a_base2k,
             j,
             &mut scratch.arena(),
         );
@@ -691,7 +700,7 @@ pub fn test_vec_znx_big_normalize<BR: crate::test_suite::TestBackend, BT: crate:
                 let res_k = res_size.saturating_sub(1).max(1) * base2k - 1;
                 let res_ref = normalize_big_to_host_with_precision(
                     module_ref,
-                    base2k,
+                    (base2k, base2k),
                     res_k,
                     res_offset,
                     res_size,
@@ -700,7 +709,7 @@ pub fn test_vec_znx_big_normalize<BR: crate::test_suite::TestBackend, BT: crate:
                 );
                 let res_test = normalize_big_to_host_with_precision(
                     module_test,
-                    base2k,
+                    (base2k, base2k),
                     res_k,
                     res_offset,
                     res_size,
@@ -709,6 +718,31 @@ pub fn test_vec_znx_big_normalize<BR: crate::test_suite::TestBackend, BT: crate:
                 );
                 assert_eq!(res_ref, res_test);
                 assert_canonical(&res_test, base2k, res_k);
+            }
+            for (a_base, res_base, res_k, offset) in super::vec_znx::cross_normalization_cases(a_size, res_size) {
+                let res_ref = normalize_big_to_host_with_precision(
+                    module_ref,
+                    (a_base, res_base),
+                    res_k,
+                    offset,
+                    res_size,
+                    &a_ref,
+                    &mut scratch_ref,
+                );
+                let res_test = normalize_big_to_host_with_precision(
+                    module_test,
+                    (a_base, res_base),
+                    res_k,
+                    offset,
+                    res_size,
+                    &a_test,
+                    &mut scratch_test,
+                );
+                assert_eq!(
+                    res_ref, res_test,
+                    "a_base={a_base} res_base={res_base} k={res_k} offset={offset}"
+                );
+                assert_canonical(&res_test, res_base, res_k);
             }
         }
     }


### PR DESCRIPTION

- **Added:** Reference and native AVX2, AVX-512/IFMA and NEON floor-carry and precision-rounding kernels, Rayon dispatch, integer-oracle tests and expanded precision benchmarks.
- **Changed:** Same-base and cross-base normalization round once at the requested precision, avoiding double rounding. Corrected `FheUint` decryption precision and strengthened wide-kernel slice checks.
- **Removed:** Separate precision-rounding helpers, per-coefficient i128 remainder operations, obsolete scalar helpers and redundant carry zeroing.
- **Others:** HAL interfaces and public scratch sizes remain unchanged

**Performance**

Representative AVX2 measurements against main `17928b12`, on an i9-12900K: release build, `VecZnxBig`, 65,536 coefficients, one column, eight input/output limbs and offset zero. Times are medians of three runs.

| Normalization | Backend | Precision `res_k` | Main | This PR | Time change |
|---|---|---:|---:|---:|---:|
| Same-base 50→50 | FFT64 | 375 | 760 µs | 279 µs | -63.3% |
| Same-base 50→50 | NTT4x30 | 375 | 1,177 µs | 812 µs | -31.0% |
| Cross-base 50→17 | FFT64 | 128 | 6,765 µs | 472 µs | -93.0% |
| Cross-base 50→17 | NTT4x30 | 128 | 8,184 µs | 1,164 µs | -85.8% |

Diff against `main`, including comments and blank lines.

| Crate | Main changes | Added | Removed | Net |
|---|---|---:|---:|---:|
| `poulpy-cpu-ref` | Reference kernels, shared algorithms, tests and benchmarks | 987 | 312 | +675 |
| `poulpy-cpu-avx512` | AVX-512/IFMA kernels, dispatch and benchmarks | 624 | 2 | +622 |
| `poulpy-cpu-avx` | AVX2 kernels, dispatch and benchmarks | 512 | 5 | +507 |
| `poulpy-cpu-arm` | NEON kernels, dispatch and benchmarks | 428 | 5 | +423 |
| `poulpy-hal` | Cross-backend tests only | 92 | 35 | +57 |
| `poulpy-cpu-rayon` | Native-kernel delegation | 20 | 1 | +19 |
| `poulpy-bench` | Precision sweep parameters and runners | 16 | 10 | +6 |
| `poulpy-bin-fhe` | Decryption precision | 2 | 2 | 0 |
| Root documentation | CHANGELOG and handoff report | 66 | 0 | +66 |
| **Total** | | **2,747** | **372** | **+2,375** |
