### PR TITLE
Jp/hal samplers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@
 - Document the value model, limb rule, mutation classes and exactness classes in the `api` and `layouts` module docs.
 - **Breaking:** `poulpy_hal::reference` moved to `poulpy_cpu_ref::reference::znx`.
 - **Breaking:** remove 30 unused api methods (coefficient shift/normalize variants, `add_const`, `add_scalar_into`, `sub_scalar`, `automorphism_rotate`, `split_ring`, `merge_rings`, `transpose`, `hadamard_product_scalar_znx`, `*_from_bytes` wrappers, `vec_znx_big_alloc_n`, `ModuleNew::new_with`) and the eight seeded `[u8; 32]` sampler twins; the `Source`-based samplers stay. The corresponding `Hal*Impl` OEP methods are removed too, including `HalModuleImpl::Config` and `new_with`.
+- **Breaking:** the secret-key samplers `scalar_znx_fill_ternary_hw_source`, `scalar_znx_fill_ternary_prob_source`, `scalar_znx_fill_binary_hw_source`, `scalar_znx_fill_binary_prob_source` and `scalar_znx_fill_binary_block_source` are removed with their OEP methods, default bodies and conformance tests; `poulpy-core` samples secrets on the host with the `ScalarZnx::fill_*` methods (which stay in `layouts` and gain unit tests) and uploads them with `Backend::copy_host_to_view`. Noise sampling (`vec_znx_add_normal_source`, `vec_znx_big_add_normal`) and `vec_znx_fill_uniform_source` stay: a backend samples noise in place from the seed, so encryption never round-trips through the host.
 
 ### `poulpy-core`
 
 - LWE/GLWE conversions and secret-key rearrangements copy through window views (`vec_znx_copy` on `window_coeffs`/`window_limbs`); no public API change.
+- `GLWESecretSampling` / `LWESecretSampling` and the public-key ephemeral secret sample on the host and upload (`scalar_znx_host_zeroed`, `upload_scalar_znx`). **Breaking:** for a fixed seed the sampled secrets change, because the HAL path derived a fresh seed per call while the host path draws from the `Source` directly.
 
 ### `poulpy-ckks`
 

--- a/poulpy-core/src/default/encryption/glwe.rs
+++ b/poulpy-core/src/default/encryption/glwe.rs
@@ -1,16 +1,14 @@
 use poulpy_hal::{
     api::{
-        ModuleN, ScalarZnxFillBinaryBlockSource, ScalarZnxFillBinaryHwSource, ScalarZnxFillBinaryProbSource,
-        ScalarZnxFillTernaryHwSource, ScalarZnxFillTernaryProbSource, ScratchArenaTakeBasic, SvpApplyDftToDft,
-        SvpApplyDftToDftAssign, SvpPPolBytesOf, SvpPrepare, VecZnxAddAssign, VecZnxAddNormalSource, VecZnxBigAddNormal,
-        VecZnxBigBytesOf, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes, VecZnxCopy, VecZnxDftApply, VecZnxDftBytesOf,
-        VecZnxFillUniformSource, VecZnxIdftApplyTmpA, VecZnxNormalize, VecZnxNormalizeAssign, VecZnxNormalizeTmpBytes,
-        VecZnxSubAssign, VecZnxSubNegateAssign, VecZnxZero,
+        ModuleN, ScratchArenaTakeBasic, SvpApplyDftToDft, SvpApplyDftToDftAssign, SvpPPolBytesOf, SvpPrepare, VecZnxAddAssign,
+        VecZnxAddNormalSource, VecZnxBigAddNormal, VecZnxBigBytesOf, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes, VecZnxCopy,
+        VecZnxDftApply, VecZnxDftBytesOf, VecZnxFillUniformSource, VecZnxIdftApplyTmpA, VecZnxNormalize, VecZnxNormalizeAssign,
+        VecZnxNormalizeTmpBytes, VecZnxSubAssign, VecZnxSubNegateAssign, VecZnxZero,
     },
     layouts::{
-        Backend, Module, PrepareHint, ScalarZnx, ScratchArena, SvpPPolToBackendRef, VecZnx, VecZnxBigToBackendMut,
-        VecZnxBigToBackendRef, VecZnxDftToBackendMut, VecZnxToBackendMut, VecZnxToBackendRef,
-        scalar_znx_as_vec_znx_backend_mut_from_mut, vec_znx_backend_ref_from_mut,
+        Backend, Module, PrepareHint, ScalarZnxToBackendMut, ScalarZnxToBackendRef, ScratchArena, SvpPPolToBackendRef, VecZnx,
+        VecZnxBigToBackendMut, VecZnxBigToBackendRef, VecZnxDftToBackendMut, VecZnxToBackendMut, VecZnxToBackendRef,
+        vec_znx_backend_ref_from_mut,
     },
     source::Source,
 };
@@ -22,6 +20,7 @@ use crate::{
         GLWEBackendRef, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, LWEInfos,
         prepared::{GLWEPreparedToBackendRef, GLWESecretPreparedToBackendRef},
     },
+    scalar_znx_host_zeroed, upload_scalar_znx,
 };
 
 #[doc(hidden)]
@@ -258,12 +257,7 @@ pub trait GLWEEncryptPkDefault<BE: Backend> {
 
 impl<BE: Backend> GLWEEncryptPkDefault<BE> for Module<BE>
 where
-    Self: GLWEEncryptPkInternal<BE>
-        + VecZnxDftBytesOf
-        + SvpPPolBytesOf
-        + VecZnxBigBytesOf
-        + VecZnxBigNormalizeTmpBytes
-        + VecZnxZero<BE>,
+    Self: GLWEEncryptPkInternal<BE> + VecZnxDftBytesOf + SvpPPolBytesOf + VecZnxBigBytesOf + VecZnxBigNormalizeTmpBytes,
 {
     fn glwe_encrypt_pk_tmp_bytes_default<A>(&self, infos: &A) -> usize
     where
@@ -363,12 +357,6 @@ where
         + VecZnxBigNormalize<BE>
         + VecZnxAddAssign<BE>
         + VecZnxCopy<BE>
-        + VecZnxZero<BE>
-        + ScalarZnxFillTernaryHwSource<BE>
-        + ScalarZnxFillTernaryProbSource<BE>
-        + ScalarZnxFillBinaryHwSource<BE>
-        + ScalarZnxFillBinaryProbSource<BE>
-        + ScalarZnxFillBinaryBlockSource<BE>
         + SvpPPolBytesOf
         + ModuleN
         + VecZnxDftBytesOf,
@@ -409,27 +397,25 @@ where
 
         {
             let (mut u_backend, scratch_2) = scratch_1.take_scalar_znx_scratch(self.n(), 1);
-            match pk.dist() {
-                Distribution::NONE => panic!(
-                    "invalid public key: SecretDistribution::NONE, ensure it has been correctly intialized through \
-                     Self::generate"
-                ),
-                Distribution::ENCAPSULATED(name) => panic!("invalid public key: secret {name} is tagged for encapsulation"),
-                Distribution::TernaryFixed(hw) => self.scalar_znx_fill_ternary_hw_source(&mut u_backend, 0, *hw, source_xu),
-                Distribution::TernaryProb(prob) => self.scalar_znx_fill_ternary_prob_source(&mut u_backend, 0, *prob, source_xu),
-                Distribution::BinaryFixed(hw) => self.scalar_znx_fill_binary_hw_source(&mut u_backend, 0, *hw, source_xu),
-                Distribution::BinaryProb(prob) => self.scalar_znx_fill_binary_prob_source(&mut u_backend, 0, *prob, source_xu),
-                Distribution::BinaryBlock(block_size) => {
-                    self.scalar_znx_fill_binary_block_source(&mut u_backend, 0, *block_size, source_xu)
+            {
+                let mut u_host = scalar_znx_host_zeroed::<BE::ZnxWord>(self.n(), 1);
+                match pk.dist() {
+                    Distribution::NONE => panic!(
+                        "invalid public key: SecretDistribution::NONE, ensure it has been correctly intialized through \
+                         Self::generate"
+                    ),
+                    Distribution::ENCAPSULATED(name) => panic!("invalid public key: secret {name} is tagged for encapsulation"),
+                    Distribution::TernaryFixed(hw) => u_host.fill_ternary_hw(0, *hw, source_xu),
+                    Distribution::TernaryProb(prob) => u_host.fill_ternary_prob(0, *prob, source_xu),
+                    Distribution::BinaryFixed(hw) => u_host.fill_binary_hw(0, *hw, source_xu),
+                    Distribution::BinaryProb(prob) => u_host.fill_binary_prob(0, *prob, source_xu),
+                    Distribution::BinaryBlock(block_size) => u_host.fill_binary_block(0, *block_size, source_xu),
+                    Distribution::ZERO => {}
                 }
-                Distribution::ZERO => {
-                    let mut u_vec = scalar_znx_as_vec_znx_backend_mut_from_mut::<BE>(&mut u_backend);
-                    self.vec_znx_zero(&mut u_vec, 0);
-                }
+                upload_scalar_znx::<BE>(&mut u_backend.to_backend_mut(), &u_host);
             }
 
-            let u_backend_ref = ScalarZnx::from_data(BE::view_ref_mut(&u_backend.data), u_backend.n(), u_backend.cols());
-            self.svp_prepare(&mut u_dft, 0, &u_backend_ref, 0);
+            self.svp_prepare(&mut u_dft, 0, &u_backend.to_backend_ref(), 0);
             scratch_1 = scratch_2;
         }
 

--- a/poulpy-core/src/default/encryption/mod.rs
+++ b/poulpy-core/src/default/encryption/mod.rs
@@ -42,6 +42,7 @@ pub mod glwe_to_lwe_key;
 pub mod lwe;
 pub mod lwe_switching_key;
 pub mod lwe_to_glwe_key;
+pub mod sampling;
 
 pub use crate::api::{EncryptionInfos, GGSWEncryptSk, GLWEEncryptSk, GLWEMaskFill, LWEFillMask};
 pub use compressed::*;
@@ -58,6 +59,7 @@ pub use lwe::*;
 pub use lwe_switching_key::*;
 pub use lwe_to_glwe_key::*;
 use poulpy_hal::layouts::NoiseInfos;
+pub use sampling::*;
 
 use crate::layouts::{GGLWEInfos, GGSWInfos, GLWEInfos, LWEInfos, TorusPrecision};
 use anyhow::Result;

--- a/poulpy-core/src/default/encryption/sampling.rs
+++ b/poulpy-core/src/default/encryption/sampling.rs
@@ -1,0 +1,38 @@
+//! Host-side secret-key sampling.
+//!
+//! Secrets are drawn on the host from a [`Source`](poulpy_hal::source::Source)
+//! with the `ScalarZnx::fill_*` methods and uploaded with
+//! [`Backend::copy_host_to_view`]. Gaussian noise is not sampled here: it is
+//! a HAL operation (`vec_znx_add_normal_source`, `vec_znx_big_add_normal`) so
+//! that a backend samples it in place and encryption never round-trips
+//! through the host.
+
+use poulpy_hal::layouts::{Backend, DataView, DataViewMut, HostBytesBackend, ScalarZnx, ScalarZnxBackendMut, ZnxWord};
+
+/// Zeroed host `ScalarZnx` with the word type of the backend it will be uploaded to.
+pub fn scalar_znx_host_zeroed<W: ZnxWord>(n: usize, cols: usize) -> ScalarZnx<Vec<u8>, W> {
+    ScalarZnx::from_data(
+        HostBytesBackend::alloc_zeroed_bytes(ScalarZnx::<Vec<u8>, W>::bytes_of(n, cols)),
+        n,
+        cols,
+    )
+}
+
+/// Uploads a host `ScalarZnx` into a backend view of the same `(n, cols)`.
+pub fn upload_scalar_znx<BE: Backend>(view: &mut ScalarZnxBackendMut<'_, BE>, host: &ScalarZnx<Vec<u8>, BE::ZnxWord>) {
+    assert_eq!(
+        (view.n(), view.cols()),
+        (host.n(), host.cols()),
+        "upload_scalar_znx: shape mismatch"
+    );
+    // Host allocations and owned backend buffers are padded to the allocator's
+    // alignment, so neither side is exactly `bytes_of` long; `copy_host_to_view`
+    // wants equal lengths. Copy exactly the shape's bytes on both sides.
+    let bytes = BE::bytes_of_scalar_znx(view.n(), view.cols());
+    assert!(
+        host.data().len() >= bytes,
+        "upload_scalar_znx: host buffer shorter than its shape"
+    );
+    let mut dst = BE::region_mut_ref(view.data_mut(), 0, bytes);
+    BE::copy_host_to_view(&mut dst, &host.data()[..bytes]);
+}

--- a/poulpy-core/src/layouts/glwe_secret.rs
+++ b/poulpy-core/src/layouts/glwe_secret.rs
@@ -1,9 +1,6 @@
 use poulpy_hal::layouts::ZnxWord;
 use poulpy_hal::{
-    api::{
-        ScalarZnxAutomorphism, ScalarZnxFillBinaryBlockSource, ScalarZnxFillBinaryHwSource, ScalarZnxFillBinaryProbSource,
-        ScalarZnxFillTernaryHwSource, ScalarZnxFillTernaryProbSource, VecZnxCopy, VecZnxZero,
-    },
+    api::{ScalarZnxAutomorphism, VecZnxCopy, VecZnxZero},
     layouts::{
         Backend, Data, HostDataMut, Module, ScalarZnx, ScalarZnxToBackendMut, ScalarZnxToBackendRef, ZnxViewMut,
         scalar_znx_as_vec_znx_backend_mut_from_mut, scalar_znx_as_vec_znx_backend_ref_from_mut, vec_znx_backend_mut_from_mut,
@@ -17,6 +14,7 @@ use crate::{
     GetDistribution, GetDistributionMut,
     dist::Distribution,
     layouts::{Base2K, Degree, GLWEInfos, LWEInfos, LWESecretToBackendMut, Rank},
+    scalar_znx_host_zeroed, upload_scalar_znx,
 };
 
 use super::{
@@ -183,12 +181,12 @@ impl<D: HostDataMut, W: ZnxWord> GLWESecret<D, W> {
     }
 }
 
-/// Secret-key sampling, dispatched to the backend.
+/// Secret-key sampling.
 ///
-/// Sampling is a backend operation like any other: it is routed through the
-/// `ScalarZnxFill*` extension points so a backend can substitute its own
-/// implementation (device-side generation, a secure element, a hardware RNG),
-/// rather than being a host-memory method on the layout.
+/// Each distribution is sampled on the host from `source` (via the
+/// `ScalarZnx::fill_*` host methods) and uploaded into the backend with
+/// [`copy_host_to_view`](poulpy_hal::layouts::Backend::copy_host_to_view),
+/// rather than being sampled by the backend itself.
 ///
 /// Each entry point fills every one of the secret's `rank` polynomials and
 /// tags it with the matching [`Distribution`]. See [`Distribution`] for what
@@ -227,24 +225,19 @@ pub trait GLWESecretSampling<BE: Backend> {
 
 impl<BE: Backend> GLWESecretSampling<BE> for Module<BE>
 where
-    Self: ScalarZnxFillTernaryProbSource<BE>
-        + ScalarZnxFillTernaryHwSource<BE>
-        + ScalarZnxFillBinaryProbSource<BE>
-        + ScalarZnxFillBinaryHwSource<BE>
-        + ScalarZnxFillBinaryBlockSource<BE>
-        + VecZnxZero<BE>,
+    Self: VecZnxZero<BE>,
 {
     fn glwe_secret_fill_ternary_prob<S>(&self, sk: &mut S, prob: f64, source: &mut Source)
     where
         S: GLWESecretToBackendMut<BE> + GetDistributionMut + GLWEInfos,
     {
         let rank: usize = sk.rank().into();
-        {
-            let mut sk_backend = sk.to_backend_mut();
-            for i in 0..rank {
-                self.scalar_znx_fill_ternary_prob_source(&mut sk_backend.data, i, prob, source);
-            }
+        let n: usize = sk.n().into();
+        let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, rank);
+        for i in 0..rank {
+            host.fill_ternary_prob(i, prob, source);
         }
+        upload_scalar_znx::<BE>(&mut sk.to_backend_mut().data, &host);
         *sk.dist_mut() = Distribution::TernaryProb(prob);
     }
 
@@ -253,12 +246,12 @@ where
         S: GLWESecretToBackendMut<BE> + GetDistributionMut + GLWEInfos,
     {
         let rank: usize = sk.rank().into();
-        {
-            let mut sk_backend = sk.to_backend_mut();
-            for i in 0..rank {
-                self.scalar_znx_fill_ternary_hw_source(&mut sk_backend.data, i, hw, source);
-            }
+        let n: usize = sk.n().into();
+        let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, rank);
+        for i in 0..rank {
+            host.fill_ternary_hw(i, hw, source);
         }
+        upload_scalar_znx::<BE>(&mut sk.to_backend_mut().data, &host);
         *sk.dist_mut() = Distribution::TernaryFixed(hw);
     }
 
@@ -267,12 +260,12 @@ where
         S: GLWESecretToBackendMut<BE> + GetDistributionMut + GLWEInfos,
     {
         let rank: usize = sk.rank().into();
-        {
-            let mut sk_backend = sk.to_backend_mut();
-            for i in 0..rank {
-                self.scalar_znx_fill_binary_prob_source(&mut sk_backend.data, i, prob, source);
-            }
+        let n: usize = sk.n().into();
+        let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, rank);
+        for i in 0..rank {
+            host.fill_binary_prob(i, prob, source);
         }
+        upload_scalar_znx::<BE>(&mut sk.to_backend_mut().data, &host);
         *sk.dist_mut() = Distribution::BinaryProb(prob);
     }
 
@@ -281,12 +274,12 @@ where
         S: GLWESecretToBackendMut<BE> + GetDistributionMut + GLWEInfos,
     {
         let rank: usize = sk.rank().into();
-        {
-            let mut sk_backend = sk.to_backend_mut();
-            for i in 0..rank {
-                self.scalar_znx_fill_binary_hw_source(&mut sk_backend.data, i, hw, source);
-            }
+        let n: usize = sk.n().into();
+        let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, rank);
+        for i in 0..rank {
+            host.fill_binary_hw(i, hw, source);
         }
+        upload_scalar_znx::<BE>(&mut sk.to_backend_mut().data, &host);
         *sk.dist_mut() = Distribution::BinaryFixed(hw);
     }
 
@@ -295,12 +288,12 @@ where
         S: GLWESecretToBackendMut<BE> + GetDistributionMut + GLWEInfos,
     {
         let rank: usize = sk.rank().into();
-        {
-            let mut sk_backend = sk.to_backend_mut();
-            for i in 0..rank {
-                self.scalar_znx_fill_binary_block_source(&mut sk_backend.data, i, block_size, source);
-            }
+        let n: usize = sk.n().into();
+        let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, rank);
+        for i in 0..rank {
+            host.fill_binary_block(i, block_size, source);
         }
+        upload_scalar_znx::<BE>(&mut sk.to_backend_mut().data, &host);
         *sk.dist_mut() = Distribution::BinaryBlock(block_size);
     }
 

--- a/poulpy-core/src/layouts/lwe_secret.rs
+++ b/poulpy-core/src/layouts/lwe_secret.rs
@@ -1,9 +1,6 @@
 use poulpy_hal::layouts::ZnxWord;
 use poulpy_hal::{
-    api::{
-        ScalarZnxFillBinaryBlockSource, ScalarZnxFillBinaryHwSource, ScalarZnxFillBinaryProbSource, ScalarZnxFillTernaryHwSource,
-        ScalarZnxFillTernaryProbSource, VecZnxZero,
-    },
+    api::VecZnxZero,
     layouts::{
         Backend, Data, HostDataRef, Module, ScalarZnx, ScalarZnxToBackendMut, ScalarZnxToBackendRef, ZnxView,
         scalar_znx_as_vec_znx_backend_mut_from_mut,
@@ -15,6 +12,7 @@ use crate::{
     GetDistribution, GetDistributionMut,
     dist::Distribution,
     layouts::{Base2K, Degree, LWEInfos},
+    scalar_znx_host_zeroed, upload_scalar_znx,
 };
 
 pub struct LWESecret<D: Data, W: ZnxWord> {
@@ -111,12 +109,13 @@ impl<D: Data, W: ZnxWord> LWEInfos for LWESecret<D, W> {
     }
 }
 
-/// Secret-key sampling, dispatched to the backend.
+/// Secret-key sampling.
 ///
 /// The LWE counterpart of [`GLWESecretSampling`](crate::layouts::GLWESecretSampling):
-/// sampling is routed through the `ScalarZnxFill*` extension points so a
-/// backend can substitute its own implementation, rather than being a
-/// host-memory method on the layout.
+/// each distribution is sampled on the host from `source` (via the
+/// `ScalarZnx::fill_*` host methods) and uploaded into the backend with
+/// [`copy_host_to_view`](poulpy_hal::layouts::Backend::copy_host_to_view),
+/// rather than being sampled by the backend itself.
 pub trait LWESecretSampling<BE: Backend> {
     /// Ternary `{-1, 0, 1}` coefficients, each non-zero with probability `prob`.
     fn lwe_secret_fill_ternary_prob<S>(&self, sk: &mut S, prob: f64, source: &mut Source)
@@ -151,12 +150,7 @@ pub trait LWESecretSampling<BE: Backend> {
 
 impl<BE: Backend> LWESecretSampling<BE> for Module<BE>
 where
-    Self: ScalarZnxFillTernaryProbSource<BE>
-        + ScalarZnxFillTernaryHwSource<BE>
-        + ScalarZnxFillBinaryProbSource<BE>
-        + ScalarZnxFillBinaryHwSource<BE>
-        + ScalarZnxFillBinaryBlockSource<BE>
-        + VecZnxZero<BE>,
+    Self: VecZnxZero<BE>,
 {
     fn lwe_secret_fill_ternary_prob<S>(&self, sk: &mut S, prob: f64, source: &mut Source)
     where
@@ -164,7 +158,10 @@ where
     {
         {
             let mut sk_backend = sk.to_backend_mut();
-            self.scalar_znx_fill_ternary_prob_source(&mut sk_backend.data, 0, prob, source);
+            let n = sk_backend.data.n();
+            let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, 1);
+            host.fill_ternary_prob(0, prob, source);
+            upload_scalar_znx::<BE>(&mut sk_backend.data, &host);
         }
         *sk.dist_mut() = Distribution::TernaryProb(prob);
     }
@@ -175,7 +172,10 @@ where
     {
         {
             let mut sk_backend = sk.to_backend_mut();
-            self.scalar_znx_fill_ternary_hw_source(&mut sk_backend.data, 0, hw, source);
+            let n = sk_backend.data.n();
+            let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, 1);
+            host.fill_ternary_hw(0, hw, source);
+            upload_scalar_znx::<BE>(&mut sk_backend.data, &host);
         }
         *sk.dist_mut() = Distribution::TernaryFixed(hw);
     }
@@ -186,7 +186,10 @@ where
     {
         {
             let mut sk_backend = sk.to_backend_mut();
-            self.scalar_znx_fill_binary_prob_source(&mut sk_backend.data, 0, prob, source);
+            let n = sk_backend.data.n();
+            let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, 1);
+            host.fill_binary_prob(0, prob, source);
+            upload_scalar_znx::<BE>(&mut sk_backend.data, &host);
         }
         *sk.dist_mut() = Distribution::BinaryProb(prob);
     }
@@ -197,7 +200,10 @@ where
     {
         {
             let mut sk_backend = sk.to_backend_mut();
-            self.scalar_znx_fill_binary_hw_source(&mut sk_backend.data, 0, hw, source);
+            let n = sk_backend.data.n();
+            let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, 1);
+            host.fill_binary_hw(0, hw, source);
+            upload_scalar_znx::<BE>(&mut sk_backend.data, &host);
         }
         *sk.dist_mut() = Distribution::BinaryFixed(hw);
     }
@@ -208,7 +214,10 @@ where
     {
         {
             let mut sk_backend = sk.to_backend_mut();
-            self.scalar_znx_fill_binary_block_source(&mut sk_backend.data, 0, block_size, source);
+            let n = sk_backend.data.n();
+            let mut host = scalar_znx_host_zeroed::<BE::ZnxWord>(n, 1);
+            host.fill_binary_block(0, block_size, source);
+            upload_scalar_znx::<BE>(&mut sk_backend.data, &host);
         }
         *sk.dist_mut() = Distribution::BinaryBlock(block_size);
     }

--- a/poulpy-cpu-arm/examples/rlwe_encrypt.rs
+++ b/poulpy-cpu-arm/examples/rlwe_encrypt.rs
@@ -12,14 +12,13 @@ use poulpy_cpu_ref::FFT64Ref as BackendImpl;
 
 use poulpy_hal::{
     api::{
-        ScalarZnxFillTernaryProbSource, ScratchOwnedAlloc, ScratchOwnedBorrow, SvpApplyDftToDftAssign, SvpPPolAlloc, SvpPrepare,
-        VecZnxAddNormalSource, VecZnxBigAddSmallAssign, VecZnxBigAlloc, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes,
-        VecZnxBigSubSmallNegateAssign, VecZnxDftAlloc, VecZnxDftApply, VecZnxFillUniformSource, VecZnxIdftApplyTmpA,
-        VecZnxNormalizeAssign,
+        ScratchOwnedAlloc, ScratchOwnedBorrow, SvpApplyDftToDftAssign, SvpPPolAlloc, SvpPrepare, VecZnxAddNormalSource,
+        VecZnxBigAddSmallAssign, VecZnxBigAlloc, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes, VecZnxBigSubSmallNegateAssign,
+        VecZnxDftAlloc, VecZnxDftApply, VecZnxFillUniformSource, VecZnxIdftApplyTmpA, VecZnxNormalizeAssign,
     },
     layouts::{
-        Module, NoiseInfos, PrepareHint, ScalarZnx, ScalarZnxToBackendMut, ScalarZnxToBackendRef, ScratchOwned, VecZnx,
-        VecZnxBigOwned, VecZnxDftOwned, VecZnxToBackendMut, VecZnxToBackendRef,
+        Module, NoiseInfos, PrepareHint, ScalarZnx, ScalarZnxToBackendRef, ScratchOwned, VecZnx, VecZnxBigOwned, VecZnxDftOwned,
+        VecZnxToBackendMut, VecZnxToBackendRef,
     },
     source::Source,
 };
@@ -40,14 +39,8 @@ fn main() {
 
     // s <- Z_{-1, 0, 1}[X]/(X^{N}+1)
     let mut s: ScalarZnx<Vec<u8>, i64> = module.scalar_znx_alloc(1);
-    // Sampled through the backend, so a backend that generates its secrets
-    // itself (device-side, secure element) substitutes its own implementation.
-    module.scalar_znx_fill_ternary_prob_source(
-        &mut ScalarZnxToBackendMut::<BackendImpl>::to_backend_mut(&mut s),
-        0,
-        0.5,
-        &mut source,
-    );
+    // Sampled on the host; `poulpy_core::GLWESecretSampling` uploads secrets to a backend the same way.
+    s.fill_ternary_prob(0, 0.5, &mut source);
 
     // Buffer to store s in the DFT domain
     let mut s_dft = module.svp_ppol_alloc(s.cols(), PrepareHint::Reuse);

--- a/poulpy-cpu-arm/src/fft64/tests.rs
+++ b/poulpy-cpu-arm/src/fft64/tests.rs
@@ -111,7 +111,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 12 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-cpu-arm/src/ntt4x30/tests.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/tests.rs
@@ -111,7 +111,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 50 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-cpu-avx/examples/rlwe_encrypt_avx.rs
+++ b/poulpy-cpu-avx/examples/rlwe_encrypt_avx.rs
@@ -22,14 +22,13 @@ use poulpy_cpu_ref::FFT64Ref as BackendImpl;
 
 use poulpy_hal::{
     api::{
-        ScalarZnxFillTernaryProbSource, ScratchOwnedAlloc, ScratchOwnedBorrow, SvpApplyDftToDftAssign, SvpPPolAlloc, SvpPrepare,
-        VecZnxAddNormalSource, VecZnxBigAddSmallAssign, VecZnxBigAlloc, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes,
-        VecZnxBigSubSmallNegateAssign, VecZnxDftAlloc, VecZnxDftApply, VecZnxFillUniformSource, VecZnxIdftApplyTmpA,
-        VecZnxNormalizeAssign,
+        ScratchOwnedAlloc, ScratchOwnedBorrow, SvpApplyDftToDftAssign, SvpPPolAlloc, SvpPrepare, VecZnxAddNormalSource,
+        VecZnxBigAddSmallAssign, VecZnxBigAlloc, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes, VecZnxBigSubSmallNegateAssign,
+        VecZnxDftAlloc, VecZnxDftApply, VecZnxFillUniformSource, VecZnxIdftApplyTmpA, VecZnxNormalizeAssign,
     },
     layouts::{
-        Module, NoiseInfos, PrepareHint, ScalarZnx, ScalarZnxToBackendMut, ScalarZnxToBackendRef, ScratchOwned, VecZnx,
-        VecZnxBigOwned, VecZnxDftOwned, VecZnxToBackendMut, VecZnxToBackendRef,
+        Module, NoiseInfos, PrepareHint, ScalarZnx, ScalarZnxToBackendRef, ScratchOwned, VecZnx, VecZnxBigOwned, VecZnxDftOwned,
+        VecZnxToBackendMut, VecZnxToBackendRef,
     },
     source::Source,
 };
@@ -50,14 +49,8 @@ fn main() {
 
     // s <- Z_{-1, 0, 1}[X]/(X^{N}+1)
     let mut s: ScalarZnx<Vec<u8>, i64> = module.scalar_znx_alloc(1);
-    // Sampled through the backend, so a backend that generates its secrets
-    // itself (device-side, secure element) substitutes its own implementation.
-    module.scalar_znx_fill_ternary_prob_source(
-        &mut ScalarZnxToBackendMut::<BackendImpl>::to_backend_mut(&mut s),
-        0,
-        0.5,
-        &mut source,
-    );
+    // Sampled on the host; `poulpy_core::GLWESecretSampling` uploads secrets to a backend the same way.
+    s.fill_ternary_prob(0, 0.5, &mut source);
 
     // Buffer to store s in the DFT domain
     let mut s_dft = module.svp_ppol_alloc(s.cols(), PrepareHint::Reuse);

--- a/poulpy-cpu-avx/src/fft64/tests.rs
+++ b/poulpy-cpu-avx/src/fft64/tests.rs
@@ -114,7 +114,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 12 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-cpu-avx/src/ntt4x30/tests.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/tests.rs
@@ -145,7 +145,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 50 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-cpu-avx512/examples/rlwe_encrypt_avx512.rs
+++ b/poulpy-cpu-avx512/examples/rlwe_encrypt_avx512.rs
@@ -12,14 +12,13 @@ use poulpy_cpu_ref::FFT64Ref as BackendImpl;
 
 use poulpy_hal::{
     api::{
-        ScalarZnxFillTernaryProbSource, ScratchOwnedAlloc, ScratchOwnedBorrow, SvpApplyDftToDftAssign, SvpPPolAlloc, SvpPrepare,
-        VecZnxAddNormalSource, VecZnxBigAddSmallAssign, VecZnxBigAlloc, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes,
-        VecZnxBigSubSmallNegateAssign, VecZnxDftAlloc, VecZnxDftApply, VecZnxFillUniformSource, VecZnxIdftApplyTmpA,
-        VecZnxNormalizeAssign,
+        ScratchOwnedAlloc, ScratchOwnedBorrow, SvpApplyDftToDftAssign, SvpPPolAlloc, SvpPrepare, VecZnxAddNormalSource,
+        VecZnxBigAddSmallAssign, VecZnxBigAlloc, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes, VecZnxBigSubSmallNegateAssign,
+        VecZnxDftAlloc, VecZnxDftApply, VecZnxFillUniformSource, VecZnxIdftApplyTmpA, VecZnxNormalizeAssign,
     },
     layouts::{
-        Module, NoiseInfos, PrepareHint, ScalarZnx, ScalarZnxToBackendMut, ScalarZnxToBackendRef, ScratchOwned, VecZnx,
-        VecZnxBigOwned, VecZnxDftOwned, VecZnxToBackendMut, VecZnxToBackendRef,
+        Module, NoiseInfos, PrepareHint, ScalarZnx, ScalarZnxToBackendRef, ScratchOwned, VecZnx, VecZnxBigOwned, VecZnxDftOwned,
+        VecZnxToBackendMut, VecZnxToBackendRef,
     },
     source::Source,
 };
@@ -40,14 +39,8 @@ fn main() {
 
     // s <- Z_{-1, 0, 1}[X]/(X^{N}+1)
     let mut s: ScalarZnx<Vec<u8>, i64> = module.scalar_znx_alloc(1);
-    // Sampled through the backend, so a backend that generates its secrets
-    // itself (device-side, secure element) substitutes its own implementation.
-    module.scalar_znx_fill_ternary_prob_source(
-        &mut ScalarZnxToBackendMut::<BackendImpl>::to_backend_mut(&mut s),
-        0,
-        0.5,
-        &mut source,
-    );
+    // Sampled on the host; `poulpy_core::GLWESecretSampling` uploads secrets to a backend the same way.
+    s.fill_ternary_prob(0, 0.5, &mut source);
 
     // Buffer to store s in the DFT domain
     let mut s_dft = module.svp_ppol_alloc(s.cols(), PrepareHint::Reuse);

--- a/poulpy-cpu-avx512/src/fft64/tests.rs
+++ b/poulpy-cpu-avx512/src/fft64/tests.rs
@@ -114,7 +114,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 12 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/tests.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/tests.rs
@@ -150,7 +150,6 @@ mod ntt3x42_ifma_tests {
         params = TestParams { size: 1<<12, base2k: 50 },
         tests = {
             test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-            test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
             test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
             test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
         }

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon_tests.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/rayon_tests.rs
@@ -114,7 +114,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 50 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/tests.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/tests.rs
@@ -145,7 +145,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 50 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-cpu-ref/src/hal_defaults/vec_znx.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/vec_znx.rs
@@ -22,8 +22,8 @@ use crate::reference::{fft64::convolution::I64Ops, ntt4x30::I128BigOps};
 use poulpy_hal::{
     api::HostBufMut,
     layouts::{
-        Backend, HostDataMut, Module, NoiseInfos, ScalarZnxBackendMut, ScalarZnxBackendRef, ScratchArena, VecZnxBackendMut,
-        VecZnxBackendRef, ZnxView, ZnxViewMut,
+        Backend, HostDataMut, Module, NoiseInfos, ScalarZnxBackendRef, ScratchArena, VecZnxBackendMut, VecZnxBackendRef, ZnxView,
+        ZnxViewMut,
     },
     source::Source,
 };
@@ -79,71 +79,6 @@ pub trait HalVecZnxDefault<BE: Backend<ZnxWord = i64>>: Backend
 where
     BE::OwnedBuf: poulpy_hal::layouts::HostDataMut,
 {
-    fn scalar_znx_fill_ternary_hw_default(
-        _module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        hw: usize,
-        seed: [u8; 32],
-    ) where
-        for<'x> BE::BufMut<'x>: HostDataMut,
-    {
-        let mut source = Source::new(seed);
-        res.fill_ternary_hw(res_col, hw, &mut source);
-    }
-
-    fn scalar_znx_fill_ternary_prob_default(
-        _module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        prob: f64,
-        seed: [u8; 32],
-    ) where
-        for<'x> BE::BufMut<'x>: HostDataMut,
-    {
-        let mut source = Source::new(seed);
-        res.fill_ternary_prob(res_col, prob, &mut source);
-    }
-
-    fn scalar_znx_fill_binary_hw_default(
-        _module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        hw: usize,
-        seed: [u8; 32],
-    ) where
-        for<'x> BE::BufMut<'x>: HostDataMut,
-    {
-        let mut source = Source::new(seed);
-        res.fill_binary_hw(res_col, hw, &mut source);
-    }
-
-    fn scalar_znx_fill_binary_prob_default(
-        _module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        prob: f64,
-        seed: [u8; 32],
-    ) where
-        for<'x> BE::BufMut<'x>: HostDataMut,
-    {
-        let mut source = Source::new(seed);
-        res.fill_binary_prob(res_col, prob, &mut source);
-    }
-
-    fn scalar_znx_fill_binary_block_default(
-        _module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        block_size: usize,
-        seed: [u8; 32],
-    ) where
-        for<'x> BE::BufMut<'x>: HostDataMut,
-    {
-        let mut source = Source::new(seed);
-        res.fill_binary_block(res_col, block_size, &mut source);
-    }
-
     fn vec_znx_zero_default(_module: &Module<BE>, res: &mut VecZnxBackendMut<'_, BE>, res_col: usize)
     where
         BE: ZnxZero,

--- a/poulpy-cpu-ref/src/hal_impl/vec_znx.rs
+++ b/poulpy-cpu-ref/src/hal_impl/vec_znx.rs
@@ -2,56 +2,6 @@
 #[macro_export]
 macro_rules! hal_impl_vec_znx_without_normalize {
     () => {
-        fn scalar_znx_fill_ternary_hw(
-            module: &Module<Self>,
-            res: &mut poulpy_hal::layouts::ScalarZnxBackendMut<'_, Self>,
-            res_col: usize,
-            hw: usize,
-            seed: [u8; 32],
-        ) {
-            <Self as HalVecZnxDefault<Self>>::scalar_znx_fill_ternary_hw_default(module, res, res_col, hw, seed)
-        }
-
-        fn scalar_znx_fill_ternary_prob(
-            module: &Module<Self>,
-            res: &mut poulpy_hal::layouts::ScalarZnxBackendMut<'_, Self>,
-            res_col: usize,
-            prob: f64,
-            seed: [u8; 32],
-        ) {
-            <Self as HalVecZnxDefault<Self>>::scalar_znx_fill_ternary_prob_default(module, res, res_col, prob, seed)
-        }
-
-        fn scalar_znx_fill_binary_hw(
-            module: &Module<Self>,
-            res: &mut poulpy_hal::layouts::ScalarZnxBackendMut<'_, Self>,
-            res_col: usize,
-            hw: usize,
-            seed: [u8; 32],
-        ) {
-            <Self as HalVecZnxDefault<Self>>::scalar_znx_fill_binary_hw_default(module, res, res_col, hw, seed)
-        }
-
-        fn scalar_znx_fill_binary_prob(
-            module: &Module<Self>,
-            res: &mut poulpy_hal::layouts::ScalarZnxBackendMut<'_, Self>,
-            res_col: usize,
-            prob: f64,
-            seed: [u8; 32],
-        ) {
-            <Self as HalVecZnxDefault<Self>>::scalar_znx_fill_binary_prob_default(module, res, res_col, prob, seed)
-        }
-
-        fn scalar_znx_fill_binary_block(
-            module: &Module<Self>,
-            res: &mut poulpy_hal::layouts::ScalarZnxBackendMut<'_, Self>,
-            res_col: usize,
-            block_size: usize,
-            seed: [u8; 32],
-        ) {
-            <Self as HalVecZnxDefault<Self>>::scalar_znx_fill_binary_block_default(module, res, res_col, block_size, seed)
-        }
-
         fn vec_znx_zero(module: &Module<Self>, res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>, res_col: usize) {
             <Self as HalVecZnxDefault<Self>>::vec_znx_zero_default(module, res, res_col)
         }

--- a/poulpy-cpu-ref/src/tests.rs
+++ b/poulpy-cpu-ref/src/tests.rs
@@ -194,8 +194,6 @@ backend_test_suite! {
     params = TestParams { size: 1<<12, base2k: 12 },
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
-        test_scalar_znx_binary_hw_has_exact_weight => poulpy_hal::test_suite::vec_znx::test_scalar_znx_binary_hw_has_exact_weight,
-        test_scalar_znx_secret_sampling => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_sampling,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,
         test_vec_znx_big_add_normal => poulpy_hal::test_suite::vec_znx_big::test_vec_znx_big_add_normal,
     }

--- a/poulpy-hal/src/api/vec_znx.rs
+++ b/poulpy-hal/src/api/vec_znx.rs
@@ -344,56 +344,6 @@ pub trait VecZnxCopy<B: Backend> {
     fn vec_znx_copy(&self, res: &mut VecZnxBackendMut<'_, B>, res_col: usize, a: &VecZnxBackendRef<'_, B>, a_col: usize);
 }
 
-pub trait ScalarZnxFillTernaryHwSource<B: Backend> {
-    fn scalar_znx_fill_ternary_hw_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        hw: usize,
-        source: &mut Source,
-    );
-}
-
-pub trait ScalarZnxFillTernaryProbSource<B: Backend> {
-    fn scalar_znx_fill_ternary_prob_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        prob: f64,
-        source: &mut Source,
-    );
-}
-
-pub trait ScalarZnxFillBinaryHwSource<B: Backend> {
-    fn scalar_znx_fill_binary_hw_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        hw: usize,
-        source: &mut Source,
-    );
-}
-
-pub trait ScalarZnxFillBinaryProbSource<B: Backend> {
-    fn scalar_znx_fill_binary_prob_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        prob: f64,
-        source: &mut Source,
-    );
-}
-
-pub trait ScalarZnxFillBinaryBlockSource<B: Backend> {
-    fn scalar_znx_fill_binary_block_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        block_size: usize,
-        source: &mut Source,
-    );
-}
-
 pub trait VecZnxFillUniformSource<B: Backend> {
     /// Fills a column with a uniform `k`-bit torus value in base `2^base2k`.
     ///

--- a/poulpy-hal/src/delegates/vec_znx.rs
+++ b/poulpy-hal/src/delegates/vec_znx.rs
@@ -1,13 +1,12 @@
 use crate::{
     api::{
-        ScalarZnxAutomorphism, ScalarZnxFillBinaryBlockSource, ScalarZnxFillBinaryHwSource, ScalarZnxFillBinaryProbSource,
-        ScalarZnxFillTernaryHwSource, ScalarZnxFillTernaryProbSource, VecZnxAdd, VecZnxAddAssign, VecZnxAddNormalSource,
-        VecZnxAddScalarAssign, VecZnxAutomorphism, VecZnxAutomorphismAssign, VecZnxAutomorphismAssignTmpBytes, VecZnxCopy,
-        VecZnxFillUniformSource, VecZnxLsh, VecZnxLshAdd, VecZnxLshAssign, VecZnxLshSub, VecZnxLshTmpBytes, VecZnxMulXpMinusOne,
-        VecZnxMulXpMinusOneAssign, VecZnxMulXpMinusOneAssignTmpBytes, VecZnxNegate, VecZnxNegateAssign, VecZnxNormalize,
-        VecZnxNormalizeAssign, VecZnxNormalizeTmpBytes, VecZnxRotate, VecZnxRotateAssign, VecZnxRotateAssignTmpBytes, VecZnxRsh,
-        VecZnxRshAdd, VecZnxRshAssign, VecZnxRshSub, VecZnxRshTmpBytes, VecZnxSub, VecZnxSubAssign, VecZnxSubNegateAssign,
-        VecZnxSwitchRing, VecZnxZero,
+        ScalarZnxAutomorphism, VecZnxAdd, VecZnxAddAssign, VecZnxAddNormalSource, VecZnxAddScalarAssign, VecZnxAutomorphism,
+        VecZnxAutomorphismAssign, VecZnxAutomorphismAssignTmpBytes, VecZnxCopy, VecZnxFillUniformSource, VecZnxLsh, VecZnxLshAdd,
+        VecZnxLshAssign, VecZnxLshSub, VecZnxLshTmpBytes, VecZnxMulXpMinusOne, VecZnxMulXpMinusOneAssign,
+        VecZnxMulXpMinusOneAssignTmpBytes, VecZnxNegate, VecZnxNegateAssign, VecZnxNormalize, VecZnxNormalizeAssign,
+        VecZnxNormalizeTmpBytes, VecZnxRotate, VecZnxRotateAssign, VecZnxRotateAssignTmpBytes, VecZnxRsh, VecZnxRshAdd,
+        VecZnxRshAssign, VecZnxRshSub, VecZnxRshTmpBytes, VecZnxSub, VecZnxSubAssign, VecZnxSubNegateAssign, VecZnxSwitchRing,
+        VecZnxZero,
     },
     layouts::{
         Backend, Module, NoiseInfos, ScalarZnxBackendMut, ScalarZnxBackendRef, ScratchArena, VecZnxBackendMut, VecZnxBackendRef,
@@ -425,71 +424,6 @@ impl_vec_znx_delegate!(
     VecZnxCopy<B>,
     fn vec_znx_copy(&self, res: &mut VecZnxBackendMut<'_, B>, res_col: usize, a: &VecZnxBackendRef<'_, B>, a_col: usize) {
         B::vec_znx_copy(self, res, res_col, a, a_col);
-    }
-);
-
-impl_vec_znx_delegate!(
-    ScalarZnxFillTernaryHwSource<B>,
-    fn scalar_znx_fill_ternary_hw_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        hw: usize,
-        source: &mut Source,
-    ) {
-        B::scalar_znx_fill_ternary_hw(self, res, res_col, hw, source.new_seed());
-    }
-);
-
-impl_vec_znx_delegate!(
-    ScalarZnxFillTernaryProbSource<B>,
-    fn scalar_znx_fill_ternary_prob_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        prob: f64,
-        source: &mut Source,
-    ) {
-        B::scalar_znx_fill_ternary_prob(self, res, res_col, prob, source.new_seed());
-    }
-);
-
-impl_vec_znx_delegate!(
-    ScalarZnxFillBinaryHwSource<B>,
-    fn scalar_znx_fill_binary_hw_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        hw: usize,
-        source: &mut Source,
-    ) {
-        B::scalar_znx_fill_binary_hw(self, res, res_col, hw, source.new_seed());
-    }
-);
-
-impl_vec_znx_delegate!(
-    ScalarZnxFillBinaryProbSource<B>,
-    fn scalar_znx_fill_binary_prob_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        prob: f64,
-        source: &mut Source,
-    ) {
-        B::scalar_znx_fill_binary_prob(self, res, res_col, prob, source.new_seed());
-    }
-);
-
-impl_vec_znx_delegate!(
-    ScalarZnxFillBinaryBlockSource<B>,
-    fn scalar_znx_fill_binary_block_source(
-        &self,
-        res: &mut ScalarZnxBackendMut<'_, B>,
-        res_col: usize,
-        block_size: usize,
-        source: &mut Source,
-    ) {
-        B::scalar_znx_fill_binary_block(self, res, res_col, block_size, source.new_seed());
     }
 );
 

--- a/poulpy-hal/src/layouts/scalar_znx.rs
+++ b/poulpy-hal/src/layouts/scalar_znx.rs
@@ -486,3 +486,60 @@ impl<D: HostDataRef, W: ZnxWord> WriterTo for ScalarZnx<D, W> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh(n: usize, cols: usize) -> ScalarZnx<Vec<u8>, i64> {
+        ScalarZnx::from_data(
+            crate::layouts::HostBytesBackend::alloc_zeroed_bytes(ScalarZnx::<Vec<u8>, i64>::bytes_of(n, cols)),
+            n,
+            cols,
+        )
+    }
+
+    #[test]
+    fn host_fills_respect_value_sets_weights_and_columns() {
+        let (n, cols, col) = (1usize << 10, 2usize, 1usize);
+        let mut source = Source::new([3u8; 32]);
+
+        let mut s = fresh(n, cols);
+        s.fill_binary_hw(col, 37, &mut source);
+        assert!(s.at(col, 0).iter().all(|&x| x == 0 || x == 1));
+        assert_eq!(s.at(col, 0).iter().filter(|&&x| x == 1).count(), 37);
+        assert!(s.at(0, 0).iter().all(|&x| x == 0), "other column untouched");
+
+        let mut s = fresh(n, cols);
+        s.fill_ternary_hw(col, 41, &mut source);
+        assert!(s.at(col, 0).iter().all(|&x| (-1..=1).contains(&x)));
+        assert_eq!(s.at(col, 0).iter().filter(|&&x| x != 0).count(), 41);
+
+        let mut s = fresh(n, cols);
+        s.fill_ternary_prob(col, 0.5, &mut source);
+        assert!(s.at(col, 0).iter().all(|&x| (-1..=1).contains(&x)));
+        assert!(s.at(col, 0).iter().any(|&x| x != 0));
+
+        let mut s = fresh(n, cols);
+        s.fill_binary_prob(col, 0.5, &mut source);
+        assert!(s.at(col, 0).iter().all(|&x| x == 0 || x == 1));
+
+        let mut s = fresh(n, cols);
+        s.fill_binary_block(col, 8, &mut source);
+        assert!(s.at(col, 0).iter().all(|&x| x == 0 || x == 1));
+        assert!(
+            s.at(col, 0)
+                .chunks(8)
+                .all(|block| block.iter().filter(|&&x| x == 1).count() <= 1)
+        );
+    }
+
+    #[test]
+    fn host_fills_are_deterministic_in_the_source() {
+        let mut a = fresh(256, 1);
+        let mut b = fresh(256, 1);
+        a.fill_ternary_hw(0, 17, &mut Source::new([9u8; 32]));
+        b.fill_ternary_hw(0, 17, &mut Source::new([9u8; 32]));
+        assert_eq!(a.at(0, 0), b.at(0, 0));
+    }
+}

--- a/poulpy-hal/src/oep/hal_impl.rs
+++ b/poulpy-hal/src/oep/hal_impl.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
-use crate::layouts::{
-    Backend, Module, NoiseInfos, ScalarZnxBackendMut, ScalarZnxBackendRef, ScratchArena, VecZnxBackendMut, VecZnxBackendRef,
-};
+use crate::layouts::{Backend, Module, NoiseInfos, ScalarZnxBackendRef, ScratchArena, VecZnxBackendMut, VecZnxBackendRef};
 
 /// Module construction extension point.
 ///
@@ -21,46 +19,6 @@ pub unsafe trait HalModuleImpl<BE: Backend>: Backend {
 /// aliasing, scratch usage, and arithmetic correctness.
 pub unsafe trait HalVecZnxImpl<BE: Backend>: Backend {
     fn vec_znx_zero(module: &Module<BE>, res: &mut VecZnxBackendMut<'_, BE>, res_col: usize);
-
-    fn scalar_znx_fill_ternary_hw(
-        module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        hw: usize,
-        seed: [u8; 32],
-    );
-
-    fn scalar_znx_fill_ternary_prob(
-        module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        prob: f64,
-        seed: [u8; 32],
-    );
-
-    fn scalar_znx_fill_binary_hw(
-        module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        hw: usize,
-        seed: [u8; 32],
-    );
-
-    fn scalar_znx_fill_binary_prob(
-        module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        prob: f64,
-        seed: [u8; 32],
-    );
-
-    fn scalar_znx_fill_binary_block(
-        module: &Module<BE>,
-        res: &mut ScalarZnxBackendMut<'_, BE>,
-        res_col: usize,
-        block_size: usize,
-        seed: [u8; 32],
-    );
 
     fn vec_znx_normalize_tmp_bytes(module: &Module<BE>) -> usize;
 

--- a/poulpy-hal/src/test_suite/vec_znx.rs
+++ b/poulpy-hal/src/test_suite/vec_znx.rs
@@ -7,18 +7,15 @@ use super::{
 
 use crate::{
     api::{
-        ModuleNew, ScalarZnxAutomorphism, ScalarZnxFillBinaryBlockSource, ScalarZnxFillBinaryHwSource,
-        ScalarZnxFillBinaryProbSource, ScalarZnxFillTernaryHwSource, ScalarZnxFillTernaryProbSource, ScratchOwnedAlloc,
-        VecZnxAdd, VecZnxAddAssign, VecZnxAddNormalSource, VecZnxAddScalarAssign, VecZnxAutomorphism, VecZnxAutomorphismAssign,
-        VecZnxAutomorphismAssignTmpBytes, VecZnxCopy, VecZnxFillUniformSource, VecZnxLsh, VecZnxLshAssign, VecZnxLshTmpBytes,
-        VecZnxMulXpMinusOne, VecZnxMulXpMinusOneAssign, VecZnxMulXpMinusOneAssignTmpBytes, VecZnxNegate, VecZnxNegateAssign,
-        VecZnxNormalize, VecZnxNormalizeAssign, VecZnxNormalizeTmpBytes, VecZnxRotate, VecZnxRotateAssign,
-        VecZnxRotateAssignTmpBytes, VecZnxRsh, VecZnxRshAssign, VecZnxRshTmpBytes, VecZnxSub, VecZnxSubAssign,
-        VecZnxSubNegateAssign, VecZnxSwitchRing, VecZnxZero,
+        ModuleNew, ScalarZnxAutomorphism, ScratchOwnedAlloc, VecZnxAdd, VecZnxAddAssign, VecZnxAddNormalSource,
+        VecZnxAddScalarAssign, VecZnxAutomorphism, VecZnxAutomorphismAssign, VecZnxAutomorphismAssignTmpBytes, VecZnxCopy,
+        VecZnxFillUniformSource, VecZnxLsh, VecZnxLshAssign, VecZnxLshTmpBytes, VecZnxMulXpMinusOne, VecZnxMulXpMinusOneAssign,
+        VecZnxMulXpMinusOneAssignTmpBytes, VecZnxNegate, VecZnxNegateAssign, VecZnxNormalize, VecZnxNormalizeAssign,
+        VecZnxNormalizeTmpBytes, VecZnxRotate, VecZnxRotateAssign, VecZnxRotateAssignTmpBytes, VecZnxRsh, VecZnxRshAssign,
+        VecZnxRshTmpBytes, VecZnxSub, VecZnxSubAssign, VecZnxSubNegateAssign, VecZnxSwitchRing, VecZnxZero,
     },
     layouts::{
-        DigestU64, FillUniform, HostBytesBackend, HostDataRef, Module, NoiseInfos, ScalarZnx, ScalarZnxToBackendMut,
-        ScratchOwned, VecZnx, ZnxView, ZnxViewMut,
+        DigestU64, FillUniform, HostBytesBackend, HostDataRef, Module, NoiseInfos, ScratchOwned, VecZnx, ZnxView, ZnxViewMut,
     },
     source::Source,
 };
@@ -1369,106 +1366,6 @@ where
     for limb in live_size..size {
         assert_eq!(a.at(0, limb), zero);
     }
-}
-
-pub fn test_scalar_znx_binary_hw_has_exact_weight<B: crate::test_suite::TestBackend>(params: &TestParams, module: &Module<B>)
-where
-    Module<B>: ScalarZnxFillBinaryHwSource<B>,
-{
-    let n = params.size;
-    let hw = n / 8;
-    let host_init = ScalarZnx::alloc(n, 1);
-    let mut sampled = upload_scalar_znx::<B>(&host_init);
-
-    module.scalar_znx_fill_binary_hw_source(
-        &mut <ScalarZnx<B::OwnedBuf, B::ZnxWord> as ScalarZnxToBackendMut<B>>::to_backend_mut(&mut sampled),
-        0,
-        hw,
-        &mut Source::new([0u8; 32]),
-    );
-
-    let sampled = download_scalar_znx::<B>(&sampled);
-    let coefficients = sampled.at(0, 0);
-
-    assert!(coefficients.iter().all(|&x| x == 0 || x == 1));
-    assert_eq!(coefficients.iter().filter(|&&x| x == 1).count(), hw);
-}
-
-pub fn test_scalar_znx_secret_sampling<B: crate::test_suite::TestBackend>(_params: &TestParams, module: &Module<B>)
-where
-    Module<B>: ScalarZnxFillTernaryHwSource<B>
-        + ScalarZnxFillTernaryProbSource<B>
-        + ScalarZnxFillBinaryProbSource<B>
-        + ScalarZnxFillBinaryBlockSource<B>,
-{
-    let n: usize = module.n();
-    let cols: usize = 2;
-    let col_i: usize = 1;
-
-    fn check<B, F>(module: &Module<B>, seed_bytes: [u8; 32], cols: usize, col_i: usize, mut fill: F) -> Vec<i64>
-    where
-        B: crate::test_suite::TestBackend,
-        F: FnMut(&mut ScalarZnx<B::OwnedBuf, B::ZnxWord>, &mut Source),
-    {
-        let mut source = Source::new(seed_bytes);
-        let host_init = ScalarZnx::alloc(module.n(), cols);
-        let mut sampled = upload_scalar_znx::<B>(&host_init);
-        fill(&mut sampled, &mut source);
-        download_scalar_znx::<B>(&sampled).at(col_i, 0).to_vec()
-    }
-
-    // Ternary, exact hamming weight: hw non-zero entries in {-1, 1}, the rest zero.
-    let hw = n / 8;
-    let coefficients = check::<B, _>(module, [2u8; 32], cols, col_i, move |res, source| {
-        module.scalar_znx_fill_ternary_hw_source(
-            &mut <ScalarZnx<B::OwnedBuf, B::ZnxWord> as ScalarZnxToBackendMut<B>>::to_backend_mut(res),
-            col_i,
-            hw,
-            source,
-        )
-    });
-    assert!(coefficients.iter().all(|&x| x == -1 || x == 0 || x == 1));
-    assert_eq!(coefficients.iter().filter(|&&x| x != 0).count(), hw);
-
-    // Ternary, probabilistic: value set is {-1, 0, 1}.
-    let coefficients = check::<B, _>(module, [3u8; 32], cols, col_i, move |res, source| {
-        module.scalar_znx_fill_ternary_prob_source(
-            &mut <ScalarZnx<B::OwnedBuf, B::ZnxWord> as ScalarZnxToBackendMut<B>>::to_backend_mut(res),
-            col_i,
-            0.5,
-            source,
-        )
-    });
-    assert!(coefficients.iter().all(|&x| x == -1 || x == 0 || x == 1));
-
-    // Binary, probabilistic: value set is {0, 1}.
-    let coefficients = check::<B, _>(module, [5u8; 32], cols, col_i, move |res, source| {
-        module.scalar_znx_fill_binary_prob_source(
-            &mut <ScalarZnx<B::OwnedBuf, B::ZnxWord> as ScalarZnxToBackendMut<B>>::to_backend_mut(res),
-            col_i,
-            0.5,
-            source,
-        )
-    });
-    assert!(coefficients.iter().all(|&x| x == 0 || x == 1));
-
-    // Binary, block-sparse: value set is {0, 1} and each block of `block_size`
-    // holds at most one 1.
-    let block_size = 8;
-    let coefficients = check::<B, _>(module, [6u8; 32], cols, col_i, move |res, source| {
-        module.scalar_znx_fill_binary_block_source(
-            &mut <ScalarZnx<B::OwnedBuf, B::ZnxWord> as ScalarZnxToBackendMut<B>>::to_backend_mut(res),
-            col_i,
-            block_size,
-            source,
-        )
-    });
-    assert!(coefficients.iter().all(|&x| x == 0 || x == 1));
-    assert!(
-        coefficients
-            .chunks(block_size)
-            .all(|block| block.iter().filter(|&&x| x == 1).count() <= 1)
-    );
 }
 
 pub fn test_vec_znx_add_normal<B: crate::test_suite::TestBackend>(_params: &TestParams, module: &Module<B>)


### PR DESCRIPTION
## Summary

PR3 of #234, on `main` after PR2 (#271). Secret sampling leaves the HAL. The five HAL operations `scalar_znx_fill_{ternary_hw, ternary_prob, binary_hw, binary_prob, binary_block}_source`, their OEP methods, delegates, default bodies and conformance tests are removed. Two paths replace them, by lifetime of the secret:

- **Long-lived secret keys** (`GLWESecretSampling`, `LWESecretSampling`): poulpy-core fills a host `ScalarZnx` with the existing `ScalarZnx::fill_*` methods and uploads it once with `Backend::copy_host_to_view`.
- **The ephemeral secret `u` of public-key encryption**: sampled in place by the backend through a new poulpy-core OEP seam, `SamplingImpl<BE>::scalar_znx_fill_distribution(module, res, col, dist: Distribution, seed)`, with **no default body**; surfaced as `ScalarZnxFillDistribution` on `Module` (taking a `&mut Source`). Nothing sampled during encryption round-trips through the host.

Noise sampling is not touched here: `vec_znx_add_normal` / `vec_znx_big_add_normal` stay HAL operations. The follow-up PR (`jp/hal-noise-oep`, stacked on this one) moves them into the same `SamplingImpl` seam.

## Why

Secret keys are generated rarely and land in an owned buffer; drawing them on the host and uploading once costs nothing and removes five OEP methods from every backend's mandatory surface. `u` and `e` are ephemeral secrets drawn inside every encryption, so they have to stay backend kernels: a host sample plus upload per encryption is exactly the round trip a device backend must never pay. The seam therefore lives in poulpy-core (the `Distribution` enum is a scheme concept), has no default body (a generic default would be that round trip), and is implemented directly by each backend; the CPU backends take it with one `poulpy_cpu_ref::impl_sampling_host!` line each.

Behaviour: for a fixed seed the sampled secret **keys** differ from before, because the HAL path derived a fresh seed per call while the host path draws from the `Source` directly. Public-key encryption is bit-identical for a fixed seed: the delegate derives one seed per call with `Source::new_seed()` and the CPU implementation runs `Source::new(seed)` then the same `fill_*`, as the HAL default body did. Distributions are unchanged everywhere.

## Added

- `poulpy-core`: `oep::SamplingImpl<BE>` (one method, `unsafe`, no default body), api trait `ScalarZnxFillDistribution<BE>`, its pure delegate, `scalar_znx_host_zeroed` and `upload_scalar_znx` for the key path (copies exactly the shape's byte count on both sides; host and owned backend buffers are padded to 64 bytes while `copy_host_to_view` wants equal lengths), and the suite test `scalar_znx_fill_distribution` in `core_backend_test_suite!` (value sets, exact weights, block structure, a two-sided band for the probabilistic variants, `ZERO`, untouched neighbour column, determinism in the seed, source advance).
- `poulpy-cpu-ref`: `impl_sampling_host!(Backend)` implementing the seam with the host `ScalarZnx::fill_*` methods applied straight to the backend buffer; `ZERO` zeroes the column (the scratch buffer is not pre-zeroed), `NONE` / `ENCAPSULATED` panic. Invoked for all 16 CPU backend types (Rayon variants and `NTT3x42Ifma` included).
- `poulpy-hal`: unit tests for the host fills `ScalarZnx::fill_*`, replacing the removed suite tests.

## Changed

- `GLWESecretSampling` / `LWESecretSampling` fill a host `ScalarZnx` and upload it.
- `glwe_encrypt_pk_internal` samples `u` with `self.scalar_znx_fill_distribution(&mut u, 0, *pk.dist(), source_xu)`; the `NONE` / `ENCAPSULATED` rejections stay at the call site. `glwe_encrypt_pk_tmp_bytes` is unchanged.
- Examples `rlwe_encrypt*`: the secret key is sampled on the host; the noise call is unchanged.
- `poulpy_core::oep` docs name `SamplingImpl` as the one `*Impl` trait without a `*Default` twin.

## Removed

- HAL api traits `ScalarZnxFillTernaryHwSource`, `ScalarZnxFillTernaryProbSource`, `ScalarZnxFillBinaryHwSource`, `ScalarZnxFillBinaryProbSource`, `ScalarZnxFillBinaryBlockSource`; OEP methods `scalar_znx_fill_*` (5); delegates; `poulpy-cpu-ref` macro arms and default bodies; suite tests `test_scalar_znx_binary_hw_has_exact_weight`, `test_scalar_znx_secret_sampling` and their registrations.

## Other

- Two earlier shapes of this PR were withdrawn: v1 (`jp/hal-samplers-v1`) also moved noise to the host; v2 (`cb0bcd60`) sampled `u` on the host and uploaded it per encryption. Both are the forbidden round trip; the ruling is that `u` and `e` are ephemeral secrets and get the same treatment.
- Secret keys transit a plain host `Vec<u8>` that is released without wiping. The workspace has no zeroization anywhere, so this matches the existing posture; it is a new host transit point for a device backend, for keys only.
- The spec's "bit-exact parity test before removal" holds for `u` by construction (same seed derivation, same `Source`, same fill) but cannot hold for the key fills: the removed default bodies derived a seed per call, so the stream differs. The key fill now advances the caller's `Source`, so later draws from that same `Source` shift as well (mask and noise use separate sources).
- Verification: portable workspace 1112, AVX2 1137, AVX-512 (IFMA, Rayon, CKKS) 2305, clippy `-D warnings`, `cargo check -p poulpy-cpu-arm --tests --examples`, `cargo build -p poulpy-cpu-avx --examples`, `cargo bench --no-run`. All green. aarch64 edited by pattern; CI is the proof.

| Crate | Files | + | − | Purpose |
|---|---|---|---|---|
| `poulpy-core` | 13 | 319 | 97 | `SamplingImpl` seam, api trait, delegate, suite test; key fills on the host and uploaded; `u` through the seam; oep docs |
| `poulpy-hal` | 5 | 72 | 276 | five fill api traits, OEP methods, delegates and two suite tests removed; host-fill unit tests added |
| `poulpy-cpu-ref` | 6 | 49 | 119 | `impl_sampling_host!`; five macro arms and default bodies removed; wiring; registrations |
| `poulpy-cpu-avx` | 4 | 11 | 16 | wiring; registrations; example |
| `poulpy-cpu-avx512` | 6 | 15 | 18 | wiring; registrations; example |
| `poulpy-cpu-arm` | 4 | 10 | 16 | wiring; registrations; example |
| `CHANGELOG.md` | 1 | 3 | 0 | Unreleased entries |
| **Total** | **39** | **479** | **542** | |
